### PR TITLE
Change TOTP handling logic

### DIFF
--- a/OktaAuthNative.xcodeproj/xcshareddata/xcschemes/OktaAuthNative iOS.xcscheme
+++ b/OktaAuthNative.xcodeproj/xcshareddata/xcschemes/OktaAuthNative iOS.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA4ED99A21C1499200A065A1"
+            BuildableName = "OktaAuthNative.framework"
+            BlueprintName = "OktaAuthNative iOS"
+            ReferencedContainer = "container:OktaAuthNative.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Source/AuthenticationClient.swift
+++ b/Source/AuthenticationClient.swift
@@ -200,7 +200,7 @@ public class AuthenticationClient {
             self?.updateStatus(response: response)
         }
     }
-    
+
     public func perform(link: LinksResponse.Link) {
         guard currentRequest == nil else {
             delegate?.handleError(.alreadyInProgress)
@@ -278,6 +278,14 @@ public class AuthenticationClient {
                 if factor.factorType == .TOTP {
                     mfaHandler.requestTOTP() { code in
                         self.verify(factor: factor, passCode: code)
+                    }
+                } else if factor.factorType == .question {
+                    guard let question = factor.profile?.questionText else {
+                        self.delegate?.handleError(.wrongState("Can't find 'question' object in response"))
+                        return
+                    }
+                    mfaHandler.securityQuestion(question: question) { answer in
+                        self.verify(factor: factor, answer: answer)
                     }
                 } else {
                     self.verify(factor: factor)

--- a/Source/OktaAPI.swift
+++ b/Source/OktaAPI.swift
@@ -25,16 +25,16 @@ open class OktaAPI {
     public private(set) var oktaDomain: URL
     public private(set) var urlSession: URLSession
 
-    open func primaryAuthentication(username: String?,
-                                    password: String?,
-                                    audience: String? = nil,
-                                    relayState: String? = nil,
-                                    multiOptionalFactorEnroll: Bool = true,
-                                    warnBeforePasswordExpired: Bool = true,
-                                    token: String? = nil,
-                                    deviceToken: String? = nil,
-                                    deviceFingerprint: String? = nil,
-                                    completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
+    @discardableResult open func primaryAuthentication(username: String?,
+                                                       password: String?,
+                                                       audience: String? = nil,
+                                                       relayState: String? = nil,
+                                                       multiOptionalFactorEnroll: Bool = true,
+                                                       warnBeforePasswordExpired: Bool = true,
+                                                       token: String? = nil,
+                                                       deviceToken: String? = nil,
+                                                       deviceFingerprint: String? = nil,
+                                                       completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.method = .post
         req.path = "/api/v1/authn"
@@ -59,10 +59,10 @@ open class OktaAPI {
         return req
     }
 
-    open func changePassword(stateToken: String,
-                             oldPassword: String,
-                             newPassword: String,
-                             completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
+    @discardableResult open func changePassword(stateToken: String,
+                                                oldPassword: String,
+                                                newPassword: String,
+                                                completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.path = "/api/v1/authn/credentials/change_password"
         req.bodyParams = ["stateToken": stateToken, "oldPassword": oldPassword, "newPassword": newPassword]
@@ -70,8 +70,8 @@ open class OktaAPI {
         return req
     }
 
-    open func getTransactionState(stateToken: String,
-                                  completion: ((OktaAPIRequest.Result) -> Void)? =  nil) -> OktaAPIRequest {
+    @discardableResult open func getTransactionState(stateToken: String,
+                                                     completion: ((OktaAPIRequest.Result) -> Void)? =  nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.path = "/api/v1/authn"
         req.bodyParams = ["stateToken": stateToken]
@@ -79,9 +79,9 @@ open class OktaAPI {
         return req
     }
     
-    open func unlockAccount(username: String,
-                            factor: FactorType,
-                            completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
+    @discardableResult open func unlockAccount(username: String,
+                                               factor: FactorType,
+                                               completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.path = "/api/v1/authn/recovery/unlock"
         req.bodyParams = ["username": username, "factorType": factor.rawValue]
@@ -89,8 +89,8 @@ open class OktaAPI {
         return req
     }
 
-    open func cancelTransaction(stateToken: String,
-                                completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
+    @discardableResult open func cancelTransaction(stateToken: String,
+                                                   completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.path = "/api/v1/authn/cancel"
         req.bodyParams = ["stateToken": stateToken]
@@ -98,9 +98,9 @@ open class OktaAPI {
         return req
     }
     
-    open func perform(link: LinksResponse.Link,
-                      stateToken: String,
-                      completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
+    @discardableResult open func perform(link: LinksResponse.Link,
+                                         stateToken: String,
+                                         completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.baseURL = link.href
         req.method = .post
@@ -109,13 +109,13 @@ open class OktaAPI {
         return req
     }
     
-    open func verifyFactor(factorId: String,
-                           stateToken: String,
-                           answer: String? = nil,
-                           passCode: String? = nil,
-                           rememberDevice: Bool? = nil,
-                           autoPush: Bool? = nil,
-                           completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
+    @discardableResult open func verifyFactor(factorId: String,
+                                              stateToken: String,
+                                              answer: String? = nil,
+                                              passCode: String? = nil,
+                                              rememberDevice: Bool? = nil,
+                                              autoPush: Bool? = nil,
+                                              completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.path = "/api/v1/authn/factors/\(factorId)/verify"
         req.method = .post

--- a/Tests/AuthenticationClientTests.swift
+++ b/Tests/AuthenticationClientTests.swift
@@ -342,6 +342,45 @@ class AuthenticationClientTests: XCTestCase {
         self.checkSuccessStateResults()
     }
     
+    func testAuthenticateWithQuestionFactorSuccessFlow() {
+        
+        var oktaApiMock = OktaAPIMock(successCase: true, resourceName: "PrimaryAuthFactorsResponse")
+        if let oktaApiMock = oktaApiMock {
+            client.api = oktaApiMock
+        } else {
+            XCTFail("Incorrect OktaApiMock usage")
+            return
+        }
+        
+        client.authenticate(username: "username", password: "password")
+        
+        wait(for: [mfaHandlerVerifyer.asyncExpectation!], timeout: 1.0)
+        
+        XCTAssertNotNil(mfaHandlerVerifyer.factors)
+        XCTAssertTrue(mfaHandlerVerifyer.selectFactorCalled, "Expected delegate method selectFactorCalled to be called")
+        XCTAssertNotNil(mfaHandlerVerifyer.selectFactorCompletion)
+        
+        mfaHandlerVerifyer.selectFactorCompletion!(mfaHandlerVerifyer.factors![3])
+        
+        XCTAssertTrue(mfaHandlerVerifyer.securityQuestionCalled, "Expected delegate method securityQuestionCalled to be called")
+        XCTAssertNotNil(mfaHandlerVerifyer.securityQuestionCompletion)
+        XCTAssertNotNil(mfaHandlerVerifyer.question)
+        XCTAssertEqual(mfaHandlerVerifyer.question, "What is your favorite piece of art?")
+        
+        oktaApiMock = OktaAPIMock(successCase: true, resourceName: "PrimaryAuthResponse")
+        if let oktaApiMock = oktaApiMock {
+            client.api = oktaApiMock
+        } else {
+            XCTFail("Incorrect OktaApiMock usage")
+        }
+        
+        mfaHandlerVerifyer.securityQuestionCompletion!("answer")
+        
+        wait(for: [delegateVerifyer.asyncExpectation!], timeout: 1.0)
+        
+        self.checkSuccessStateResults()
+    }
+    
     func testVerifyPushSuccessFlow() {
         
         var oktaApiMock = OktaAPIMock(successCase: true, resourceName: "PrimaryAuthFactorsResponse")

--- a/Tests/Mocks/AuthenticationClientMFAHandlerVerifyer.swift
+++ b/Tests/Mocks/AuthenticationClientMFAHandlerVerifyer.swift
@@ -53,6 +53,7 @@ class AuthenticationClientMFAHandlerVerifyer: AuthenticationClientMFAHandler {
         
         securityQuestionCalled = true
         self.question = question
+        self.securityQuestionCompletion = callback
         if let expectation = asyncExpectation {
             expectation.fulfill()
         }
@@ -66,6 +67,7 @@ class AuthenticationClientMFAHandlerVerifyer: AuthenticationClientMFAHandler {
     var selectFactorCompletion: ((_ factor: EmbeddedResponse.Factor) -> Void)?
     var requestSMSCodeCompletion: ((_ code: String) -> Void)?
     var requestTOTPCodeCompletion: ((_ code: String) -> Void)?
+    var securityQuestionCompletion: ((_ answer: String) -> Void)?
     
     var selectFactorCalled: Bool = false
     var pushStateUpdatedCalled: Bool = false

--- a/Tests/OktaAPITests.swift
+++ b/Tests/OktaAPITests.swift
@@ -34,7 +34,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
         
-        _ = api.primaryAuthentication(username: username, password: password)
+        api.primaryAuthentication(username: username, password: password)
         
         wait(for: [exp], timeout: 60.0)
     }
@@ -54,7 +54,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
         
-        _ = api.primaryAuthentication(username: username, password: password, deviceFingerprint: deviceFingerprint)
+        api.primaryAuthentication(username: username, password: password, deviceFingerprint: deviceFingerprint)
         
         wait(for: [exp], timeout: 60.0)
     }
@@ -74,7 +74,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
         
-        _ = api.changePassword(stateToken: token, oldPassword: oldpass, newPassword: newpass)
+        api.changePassword(stateToken: token, oldPassword: oldpass, newPassword: newpass)
         
         wait(for: [exp], timeout: 60.0)
     }
@@ -90,7 +90,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
         
-        _ = api.getTransactionState(stateToken: token)
+        api.getTransactionState(stateToken: token)
         
         wait(for: [exp], timeout: 60.0)
     }
@@ -106,7 +106,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
         
-        _ = api.cancelTransaction(stateToken: token)
+        api.cancelTransaction(stateToken: token)
         
         wait(for: [exp], timeout: 60.0)
     }
@@ -122,7 +122,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
         
-        _ = api.perform(link: link, stateToken: token)
+        api.perform(link: link, stateToken: token)
         
         wait(for: [exp], timeout: 60.0)
     }
@@ -145,7 +145,7 @@ class OktaAPITests : XCTestCase {
             exp.fulfill()
         }
 
-        _ = api.verifyFactor(factorId: factorId,
+        api.verifyFactor(factorId: factorId,
                          stateToken: token,
                          answer: answer,
                          passCode: passCode,

--- a/Tests/Resources/PrimaryAuthFactorsResponse
+++ b/Tests/Resources/PrimaryAuthFactorsResponse
@@ -71,6 +71,22 @@
                     }
                 }
             }
+        }, {
+            "id": "question1981BEROPBNZKPPE",
+            "factorType": "question",
+            "provider": "OKTA",
+            "profile": {
+                "question": "favorite_art_piece",
+                "questionText": "What is your favorite piece of art?"
+            },
+            "_links": {
+                "verify": {
+                    "href": "https://test.sandbox.com/api/v1/authn/factors/question1981BEROPBNZKPPE/verify",
+                    "hints": {
+                        "allow": ["POST"]
+                    }
+                }
+            }
         }],
         "policy": {
             "allowRememberDevice": false,


### PR DESCRIPTION
### Problem Analysis (Technical)
- TOTP factor doesn't require switching to MFAChallenge state. So we can request TOTP code immediately from the user instead of sending superfluous "verify" network call.
Related issue: #126.

### Solution (Technical)
- Change handling of TOTP factor once selected by the user

### Affected Components
AuthenticationClient class

### Tests
Fixed `testAuthenticateWithTOTPFactorSuccessFlow` test according to new logic