### PR TITLE
OKTA-214174-AuthN iOS SDK: Incorrect url link is used for skip passwo…

### DIFF
--- a/Source/AuthenticationClient.swift
+++ b/Source/AuthenticationClient.swift
@@ -228,11 +228,11 @@ public class AuthenticationClient {
         case .passwordWarning:
             delegate?.handleChangePassword(canSkip: true, callback: { [weak self] old, new, skip in
                 if skip {
-                    guard let next = self?.links?.next else {
-                        self?.delegate?.handleError(.wrongState("Can't find 'next' link in response"))
+                    guard let skipLink = self?.links?.skip else {
+                        self?.delegate?.handleError(.wrongState("Can't find 'skip' link in response"))
                         return
                     }
-                    self?.perform(link: next)
+                    self?.perform(link: skipLink)
                 } else {
                     self?.changePassword(oldPassword: old ?? "", newPassword: new ?? "")
                 }

--- a/Tests/AuthenticationClientTests.swift
+++ b/Tests/AuthenticationClientTests.swift
@@ -147,7 +147,7 @@ class AuthenticationClientTests: XCTestCase {
         delegateVerifyer.handleChangePasswordCompletion?(nil, nil, true)
         XCTAssertTrue(delegateVerifyer.handleErrorCalled, "Expected delegate method handleErrorCalled to be called")
         XCTAssertNotNil(delegateVerifyer.error)
-        XCTAssertEqual(delegateVerifyer.error?.description, OktaError.wrongState("Can't find 'next' link in response").description)
+        XCTAssertEqual(delegateVerifyer.error?.description, OktaError.wrongState("Can't find 'skip' link in response").description)
     }
     
     func testPasswordWarningWithNoPasswordChangeSuccessFlow() {
@@ -180,6 +180,8 @@ class AuthenticationClientTests: XCTestCase {
         delegateVerifyer.asyncExpectation = XCTestExpectation()
         delegateVerifyer.handleChangePasswordCompletion?(nil, nil, true)
         XCTAssertTrue(oktaApiMock!.performCalled)
+        XCTAssertNotNil(oktaApiMock!.performedLink)
+        XCTAssertEqual(client.links?.skip?.href, oktaApiMock!.performedLink?.href)
         
         wait(for: [delegateVerifyer.asyncExpectation!], timeout: 1.0)
         

--- a/Tests/Mocks/OktaAPIMock.swift
+++ b/Tests/Mocks/OktaAPIMock.swift
@@ -174,6 +174,7 @@ class OktaAPIMock: OktaAPI {
         }
         
         self.performCalled = true
+        self.performedLink = link
         let req = OktaAPIRequest(baseURL: URL(string: "https://dummy.url")!,
                                  urlSession: URLSession(configuration: .default),
                                  completion: { _ = $0; _ = $1})
@@ -189,4 +190,6 @@ class OktaAPIMock: OktaAPI {
     var getTransactionStateCalled: Bool = false
     var verifyFactorCalled: Bool = false
     var performCalled: Bool = false
+
+    var performedLink: LinksResponse.Link?
 }


### PR DESCRIPTION
…rd functionality

### Problem Analysis (Technical)
Incorrect url link is used for skipping password change flow

### Solution (Technical)
Set correct link

### Affected Components
AuthenticationClient

### Steps to reproduce:

1. Trigger PasswordWarning status during auth flow
2. Select skip password change option

Actual outcome:
SDK uses "next" url link for skip action. However "next" url link should be used for password change

Expected outcome:
SDK uses "skip" url link for skip action

### Tests
testPasswordWarningWithNoPasswordChangeSuccessFlow
testPasswordChangeErrorFlows
