### PR TITLE
OKTA-218465-iOS AuthN SDK: 1.0 refactor work, take out of beta

### DIFF
--- a/Source/DomainObjects/OktaModels.swift
+++ b/Source/DomainObjects/OktaModels.swift
@@ -37,7 +37,7 @@ public struct OktaAPISuccessResponse: Codable {
     public private(set) var status: AuthStatus?
     public private(set) var stateToken: String?
     public private(set) var sessionToken: String?
-    public private(set) var expirationDate: Date?
+    public private(set) var expirationDate: String?
     public private(set) var relayState: String?
     public private(set) var recoveryToken: String?
     public private(set) var recoveryType: RecoveryType?

--- a/Source/RestAPI/OktaAPI.swift
+++ b/Source/RestAPI/OktaAPI.swift
@@ -117,12 +117,14 @@ open class OktaAPI {
     }
 
     @discardableResult open func recoverWith(answer: String?,
+                                             stateToken: String,
                                              recoveryToken: String?,
                                              link: LinksResponse.Link,
                                              completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.baseURL = link.href
         req.bodyParams = [:]
+        req.bodyParams = ["stateToken": stateToken]
         req.bodyParams?["answer"] = answer
         req.bodyParams?["recoveryToken"] = recoveryToken
         req.run()
@@ -130,11 +132,13 @@ open class OktaAPI {
     }
 
     @discardableResult open func resetPassword(newPassword: String,
+                                               stateToken: String,
                                                link: LinksResponse.Link,
                                                completion: ((OktaAPIRequest.Result) -> Void)? = nil) -> OktaAPIRequest {
         let req = buildBaseRequest(completion: completion)
         req.baseURL = link.href
         req.bodyParams = ["newPassword": newPassword]
+        req.bodyParams?["stateToken"] = stateToken
         req.run()
         return req
     }

--- a/Source/Statuses/OktaAuthStatePasswordReset.swift
+++ b/Source/Statuses/OktaAuthStatePasswordReset.swift
@@ -37,7 +37,7 @@ open class OktaAuthStatusPasswordReset : OktaAuthStatus {
             return
         }
 
-        restApi.resetPassword(newPassword: newPassword, link: model.links!.next!) { result in
+        restApi.resetPassword(newPassword: newPassword, stateToken: stateToken, link: model.links!.next!) { result in
             self.handleServerResponse(result,
                                       onStatusChanged: onStatusChange,
                                       onError: onError)

--- a/Source/Statuses/OktaAuthStatusRecovery.swift
+++ b/Source/Statuses/OktaAuthStatusRecovery.swift
@@ -13,6 +13,8 @@
 import Foundation
 
 open class OktaAuthStatusRecovery : OktaAuthStatus {
+
+    public internal(set) var stateToken: String
     
     open var recoveryQuestion: String? {
         get {
@@ -48,7 +50,9 @@ open class OktaAuthStatusRecovery : OktaAuthStatus {
             return
         }
         
-        restApi.recoverWith(answer: answer, recoveryToken: nil, link: model.links!.next!) { result in
+        restApi.recoverWith(answer: answer,
+                            stateToken: stateToken,
+                            recoveryToken: nil, link: model.links!.next!) { result in
                 self.handleServerResponse(result,
                                           onStatusChanged: onStatusChange,
                                           onError: onError)
@@ -63,7 +67,9 @@ open class OktaAuthStatusRecovery : OktaAuthStatus {
             return
         }
         
-        restApi.recoverWith(answer: nil, recoveryToken: recoveryToken, link: model.links!.next!) { result in
+        restApi.recoverWith(answer: nil,
+                            stateToken: stateToken,
+                            recoveryToken: recoveryToken, link: model.links!.next!) { result in
             self.handleServerResponse(result,
                                       onStatusChanged: onStatusChange,
                                       onError: onError)
@@ -71,6 +77,10 @@ open class OktaAuthStatusRecovery : OktaAuthStatus {
     }
     
     override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
         try super.init(currentState: currentState, model: model)
         statusType = .recovery
     }


### PR DESCRIPTION
### Problem Analysis (Technical)
- Recovery flows require state token
- Expiration date for Recovery_Challenge is sent in non-iso format and cause "data corrupted" error

### Solution (Technical)
- Add state token to required REST requests
- Change type for `Expires_At` field to `String`

### Affected Components
OktaModels
OktaApi
OktaAuthStatusRecovery

### Tests
In progress
