### PR TITLE
OKTA-218465-iOS AuthN SDK: 1.0 refactor work, take out of beta

### DIFF
--- a/Source/Factors/OktaFactor.swift
+++ b/Source/Factors/OktaFactor.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-protocol OktaFactorResultProtocol: class {
+public protocol OktaFactorResultProtocol: class {
     func handleFactorServerResponse(response: OktaAPIRequest.Result,
                                     onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                                     onError: @escaping (_ error: OktaError) -> Void,
@@ -64,8 +64,20 @@ open class OktaFactor {
                                    activationLink: activationLink)
         }
     }
-    
-    public internal(set) var factor: EmbeddedResponse.Factor
+
+    public init(factor: EmbeddedResponse.Factor,
+                stateToken: String,
+                verifyLink: LinksResponse.Link?,
+                activationLink: LinksResponse.Link?) {
+        self.factor = factor
+        self.stateToken = stateToken
+        self.verifyLink = verifyLink
+        self.activationLink = activationLink
+    }
+
+    public weak var responseDelegate: OktaFactorResultProtocol?
+    public var restApi: OktaAPI?
+    public var factor: EmbeddedResponse.Factor
 
     // REQUIRED, OPTIONAL
     public var enrollment: String? {
@@ -214,23 +226,11 @@ open class OktaFactor {
                           onError: onError,
                           onFactorStatusUpdate: nil)
     }
-    
-    weak var responseDelegate: OktaFactorResultProtocol?
+
     var stateToken: String
-    var restApi: OktaAPI?
     var verifyLink: LinksResponse.Link?
     var activationLink: LinksResponse.Link?
     var cancelled = false
-    
-    init(factor: EmbeddedResponse.Factor,
-         stateToken: String,
-         verifyLink: LinksResponse.Link?,
-         activationLink: LinksResponse.Link?) {
-        self.factor = factor
-        self.stateToken = stateToken
-        self.verifyLink = verifyLink
-        self.activationLink = activationLink
-    }
 
     func cancel() {
         cancelled = true

--- a/Source/Statuses/OktaAuthStatePasswordReset.swift
+++ b/Source/Statuses/OktaAuthStatePasswordReset.swift
@@ -16,6 +16,24 @@ open class OktaAuthStatusPasswordReset : OktaAuthStatus {
 
     public internal(set) var stateToken: String
 
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
+        if let policy = model.embedded?.policy {
+            switch policy {
+            case .password(let password):
+                passwordExpiration = password.expiration
+                passwordComplexity = password.complexity
+            default:
+                break
+            }
+        }
+        try super.init(currentState: currentState, model: model)
+        statusType = .passwordReset
+    }
+
     open var passwordExpiration: EmbeddedResponse.Policy.Password.PasswordExpiration?
 
     open var passwordComplexity: EmbeddedResponse.Policy.Password.PasswordComplexity?
@@ -42,23 +60,5 @@ open class OktaAuthStatusPasswordReset : OktaAuthStatus {
                                       onStatusChanged: onStatusChange,
                                       onError: onError)
         }
-    }
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        guard let stateToken = model.stateToken else {
-            throw OktaError.invalidResponse
-        }
-        self.stateToken = stateToken
-        if let policy = model.embedded?.policy {
-            switch policy {
-            case .password(let password):
-                passwordExpiration = password.expiration
-                passwordComplexity = password.complexity
-            default:
-                break
-            }
-        }
-        try super.init(currentState: currentState, model: model)
-        statusType = .passwordReset
     }
 }

--- a/Source/Statuses/OktaAuthStatus.swift
+++ b/Source/Statuses/OktaAuthStatus.swift
@@ -14,13 +14,13 @@ import Foundation
 
 open class OktaAuthStatus {
 
-    public internal(set) var restApi: OktaAPI
+    public var restApi: OktaAPI
 
-    public internal(set) var statusType : AuthStatus = .unknown("Unknown status")
+    public var statusType : AuthStatus = .unknown("Unknown status")
 
-    public internal(set) var model: OktaAPISuccessResponse
+    public var model: OktaAPISuccessResponse
 
-    public internal(set) var responseHandler: OktaAuthStatusResponseHandler
+    public var responseHandler: OktaAuthStatusResponseHandler
 
     public init(oktaDomain: URL,
                 responseHandler: OktaAuthStatusResponseHandler = OktaAuthStatusResponseHandler()) {

--- a/Source/Statuses/OktaAuthStatusFactorEnroll.swift
+++ b/Source/Statuses/OktaAuthStatusFactorEnroll.swift
@@ -15,6 +15,19 @@ import Foundation
 open class OktaAuthStatusFactorEnroll : OktaAuthStatus {
     
     public internal(set) var stateToken: String
+    
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        guard let factors = model.embedded?.factors else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
+        self.factors = factors
+        try super.init(currentState: currentState, model: model)
+        statusType = .MFAEnroll
+    }
 
     open lazy var availableFactors: [OktaFactor] = {
         var oktaFactors = Array<OktaFactor>()
@@ -83,26 +96,13 @@ open class OktaAuthStatusFactorEnroll : OktaAuthStatus {
 
     var factors: [EmbeddedResponse.Factor]
     var selectedFactor: OktaFactor?
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        guard let stateToken = model.stateToken else {
-            throw OktaError.invalidResponse
-        }
-        guard let factors = model.embedded?.factors else {
-            throw OktaError.invalidResponse
-        }
-        self.stateToken = stateToken
-        self.factors = factors
-        try super.init(currentState: currentState, model: model)
-        statusType = .MFAEnroll
-    }
 }
 
 extension OktaAuthStatusFactorEnroll: OktaFactorResultProtocol {
-    func handleFactorServerResponse(response: OktaAPIRequest.Result,
-                                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                    onError: @escaping (_ error: OktaError) -> Void,
-                                    onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
+    public func handleFactorServerResponse(response: OktaAPIRequest.Result,
+                                           onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
+                                           onError: @escaping (_ error: OktaError) -> Void,
+                                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
         self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
     }
 }

--- a/Source/Statuses/OktaAuthStatusFactorRequired.swift
+++ b/Source/Statuses/OktaAuthStatusFactorRequired.swift
@@ -16,6 +16,19 @@ open class OktaAuthStatusFactorRequired : OktaAuthStatus {
     
     public internal(set) var stateToken: String
 
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        guard let factors = model.embedded?.factors else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
+        self.factors = factors
+        try super.init(currentState: currentState, model: model)
+        statusType = .MFARequired
+    }
+
     open lazy var availableFactors: [OktaFactor] = {
         var oktaFactors = Array<OktaFactor>()
         for factor in self.factors {
@@ -46,26 +59,13 @@ open class OktaAuthStatusFactorRequired : OktaAuthStatus {
 
     var factors: [EmbeddedResponse.Factor]
     var selectedFactor: OktaFactor?
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        guard let stateToken = model.stateToken else {
-            throw OktaError.invalidResponse
-        }
-        guard let factors = model.embedded?.factors else {
-            throw OktaError.invalidResponse
-        }
-        self.stateToken = stateToken
-        self.factors = factors
-        try super.init(currentState: currentState, model: model)
-        statusType = .MFARequired
-    }
 }
 
 extension OktaAuthStatusFactorRequired: OktaFactorResultProtocol {
-    func handleFactorServerResponse(response: OktaAPIRequest.Result,
-                                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                    onError: @escaping (_ error: OktaError) -> Void,
-                                    onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
+    public func handleFactorServerResponse(response: OktaAPIRequest.Result,
+                                           onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
+                                           onError: @escaping (_ error: OktaError) -> Void,
+                                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
         self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
     }
 }

--- a/Source/Statuses/OktaAuthStatusLockedOut.swift
+++ b/Source/Statuses/OktaAuthStatusLockedOut.swift
@@ -14,6 +14,11 @@ import Foundation
 
 open class OktaAuthStatusLockedOut : OktaAuthStatus {
 
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        try super.init(currentState: currentState, model: model)
+        statusType = .lockedOut
+    }
+
     open func canUnlock() -> Bool {
         guard model.links?.next?.href != nil else {
             return false
@@ -40,10 +45,5 @@ open class OktaAuthStatusLockedOut : OktaAuthStatus {
         } catch let error {
             onError(error as! OktaError)
         }
-    }
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        try super.init(currentState: currentState, model: model)
-        statusType = .lockedOut
     }
 }

--- a/Source/Statuses/OktaAuthStatusPasswordExpired.swift
+++ b/Source/Statuses/OktaAuthStatusPasswordExpired.swift
@@ -16,6 +16,15 @@ open class OktaAuthStatusPasswordExpired : OktaAuthStatus {
     
     public internal(set) var stateToken: String
 
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
+        try super.init(currentState: currentState, model: model)
+        statusType = .passwordExpired
+    }
+
     open func canChange() -> Bool {
         
         guard (model.links?.next?.href) != nil else {
@@ -44,14 +53,5 @@ open class OktaAuthStatusPasswordExpired : OktaAuthStatus {
                                       onStatusChanged: onStatusChange,
                                       onError: onError)
         }
-    }
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        guard let stateToken = model.stateToken else {
-            throw OktaError.invalidResponse
-        }
-        self.stateToken = stateToken
-        try super.init(currentState: currentState, model: model)
-        statusType = .passwordExpired
     }
 }

--- a/Source/Statuses/OktaAuthStatusPasswordWarning.swift
+++ b/Source/Statuses/OktaAuthStatusPasswordWarning.swift
@@ -15,6 +15,15 @@ import Foundation
 open class OktaAuthStatusPasswordWarning : OktaAuthStatus {
     
     public internal(set) var stateToken: String
+
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
+        try super.init(currentState: currentState, model: model)
+        statusType = .passwordWarning
+    }
     
     open func canChange() -> Bool {
         
@@ -63,14 +72,5 @@ open class OktaAuthStatusPasswordWarning : OktaAuthStatus {
                                       onStatusChanged: onStatusChange,
                                       onError: onError)
         }
-    }
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        guard let stateToken = model.stateToken else {
-            throw OktaError.invalidResponse
-        }
-        self.stateToken = stateToken
-        try super.init(currentState: currentState, model: model)
-        statusType = .passwordWarning
     }
 }

--- a/Source/Statuses/OktaAuthStatusRecovery.swift
+++ b/Source/Statuses/OktaAuthStatusRecovery.swift
@@ -15,6 +15,15 @@ import Foundation
 open class OktaAuthStatusRecovery : OktaAuthStatus {
 
     public internal(set) var stateToken: String
+
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        guard let stateToken = model.stateToken else {
+            throw OktaError.invalidResponse
+        }
+        self.stateToken = stateToken
+        try super.init(currentState: currentState, model: model)
+        statusType = .recovery
+    }
     
     open var recoveryQuestion: String? {
         get {
@@ -74,14 +83,5 @@ open class OktaAuthStatusRecovery : OktaAuthStatus {
                                       onStatusChanged: onStatusChange,
                                       onError: onError)
         }
-    }
-    
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        guard let stateToken = model.stateToken else {
-            throw OktaError.invalidResponse
-        }
-        self.stateToken = stateToken
-        try super.init(currentState: currentState, model: model)
-        statusType = .recovery
     }
 }

--- a/Source/Statuses/OktaAuthStatusRecoveryChallenge.swift
+++ b/Source/Statuses/OktaAuthStatusRecoveryChallenge.swift
@@ -14,6 +14,11 @@ import Foundation
 
 open class OktaAuthStatusRecoveryChallenge : OktaAuthStatus {
 
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+        try super.init(currentState: currentState, model: model)
+        statusType = .recoveryChallenge
+    }
+
     open var recoveryType: OktaAPISuccessResponse.RecoveryType? {
         get {
             return model.recoveryType
@@ -125,10 +130,5 @@ open class OktaAuthStatusRecoveryChallenge : OktaAuthStatus {
                                                       onStatusChanged: onStatusChange,
                                                       onError: onError)
         })
-    }
-
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
-        try super.init(currentState: currentState, model: model)
-        statusType = .recoveryChallenge
     }
 }

--- a/Source/Statuses/OktaAuthStatusSuccess.swift
+++ b/Source/Statuses/OktaAuthStatusSuccess.swift
@@ -16,7 +16,7 @@ open class OktaAuthStatusSuccess : OktaAuthStatus {
     
     public var sessionToken: String
 
-    override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
+    public override init(currentState: OktaAuthStatus, model: OktaAPISuccessResponse) throws {
         guard let sessionToken = model.sessionToken else {
             throw OktaError.invalidResponse
         }


### PR DESCRIPTION
### Problem Analysis (Technical)
Constructors and some of the properties are marked as `internal` and can't be used in inherited classes on application level

### Solution (Technical)
Make constructors and properties public
