### PR TITLE
OKTA-234954-AuthN iOS SDK: Push factor polling doesn't stop if user taps on back button

### DIFF
--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
         guard let username = usernameField.text,
             let password = passwordField.text else { return }
 
-        OktaAuthSdk.authenticate(with: URL(string: "https://dev-949814.okta.com")!,
+        OktaAuthSdk.authenticate(with: URL(string: "https://{yourOktaDomain}")!,
                                  username: username,
                                  password: password,
                                  onStatusChange: { authStatus in

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
         guard let username = usernameField.text,
             let password = passwordField.text else { return }
 
-        OktaAuthSdk.authenticate(with: URL(string: "https://{yourOktaDomain}")!,
+        OktaAuthSdk.authenticate(with: URL(string: "https://dev-949814.okta.com")!,
                                  username: username,
                                  password: password,
                                  onStatusChange: { authStatus in
@@ -58,7 +58,7 @@ class ViewController: UIViewController {
             
         case .success:
             let successState: OktaAuthStatusSuccess = status as! OktaAuthStatusSuccess
-            handleSuccessStatus(sessionToken: successState.sessionToken)
+            handleSuccessStatus(sessionToken: successState.sessionToken!)
 
         case .passwordWarning:
             let warningPasswordStatus: OktaAuthStatusPasswordWarning = status as! OktaAuthStatusPasswordWarning
@@ -112,7 +112,7 @@ class ViewController: UIViewController {
              .passwordReset,
              .lockedOut,
              .unauthenticated:
-              let alert = UIAlertController(title: "Error", message: "No handler for \(status.statusType.description)", preferredStyle: .alert)
+              let alert = UIAlertController(title: "Error", message: "No handler for \(status.statusType.rawValue)", preferredStyle: .alert)
               alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
               present(alert, animated: true, completion: nil)
               self.cancelTransaction()
@@ -132,9 +132,9 @@ class ViewController: UIViewController {
         }
 
         if let factorResult = factorResult {
-            stateLabel.text = "\(status.statusType.description) \(factorResult.rawValue)"
+            stateLabel.text = "\(status.statusType.rawValue) \(factorResult.rawValue)"
         } else {
-            stateLabel.text = status.statusType.description
+            stateLabel.text = status.statusType.rawValue
         }
     }
 
@@ -186,7 +186,7 @@ class ViewController: UIViewController {
         
         let alert = UIAlertController(title: "Select verification factor", message: nil, preferredStyle: .actionSheet)
         factorRequiredStatus.availableFactors.forEach { factor in
-            alert.addAction(UIAlertAction(title: factor.type.description, style: .default, handler: { _ in
+            alert.addAction(UIAlertAction(title: factor.type.rawValue, style: .default, handler: { _ in
                 factorRequiredStatus.selectFactor(factor,
                                                   onStatusChange: { status in
                     self.handleStatus(status: status)
@@ -215,7 +215,7 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: "Select factor to enroll", message: nil, preferredStyle: .actionSheet)
         let factors = enrollmentStatus.availableFactors
         factors.forEach { factor in
-            var title = factor.type.description
+            var title = factor.type.rawValue
             if let factorStatus = factor.status {
                 title = title + " - " + "(\(factorStatus))"
             }
@@ -243,7 +243,7 @@ class ViewController: UIViewController {
                         self.handleError(error)
                     })
                 } else {
-                    let alert = UIAlertController(title: "Error", message: "No handler for \(factor.type.description) factor", preferredStyle: .alert)
+                    let alert = UIAlertController(title: "Error", message: "No handler for \(factor.type.rawValue) factor", preferredStyle: .alert)
                     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                     self.present(alert, animated: true, completion: nil)
                     self.cancelTransaction()
@@ -261,7 +261,7 @@ class ViewController: UIViewController {
         let factor = status.factor
         guard factor.type == .sms ||
               factor.type == .push else {
-            let alert = UIAlertController(title: "Error", message: "No handler for \(factor.type.description) factor", preferredStyle: .alert)
+            let alert = UIAlertController(title: "Error", message: "No handler for \(factor.type.rawValue) factor", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
             self.present(alert, animated: true, completion: nil)
             self.cancelTransaction()
@@ -281,9 +281,6 @@ class ViewController: UIViewController {
                 },
                                       onError: { error in
                                         self.handleError(error)
-                },
-                                      onFactorStatusUpdate: { factorResult in
-                                        self.updateStatus(status: self.currentStatus, factorResult: factorResult)
                 })
             }))
             alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
@@ -297,9 +294,7 @@ class ViewController: UIViewController {
                     self.handleStatus(status: status)
                 }, onError: { error in
                     self.handleError(error)
-                }) { factorResult in
-                    self.updateStatus(status: status, factorResult: factorResult)
-                }
+                })
             }
         }
     }
@@ -315,9 +310,6 @@ class ViewController: UIViewController {
             },
                            onError: { error in
                             self.handleError(error)
-            },
-                           onFactorStatusUpdate: { factorResult in
-                            self.updateStatus(status: self.currentStatus, factorResult: factorResult)
             })
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
@@ -337,9 +329,6 @@ class ViewController: UIViewController {
             },
                            onError: { error in
                             self.handleError(error)
-            },
-                           onFactorStatusUpdate: { factorResult in
-                self.updateStatus(status: self.currentStatus, factorResult: factorResult)
             })
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
@@ -359,9 +348,6 @@ class ViewController: UIViewController {
             },
                            onError: { error in
                             self.handleError(error)
-            },
-                           onFactorStatusUpdate: { factorResult in
-                            self.updateStatus(status: self.currentStatus, factorResult: factorResult)
             })
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
@@ -371,14 +357,18 @@ class ViewController: UIViewController {
     }
 
     func handlePushChallenge(factor: OktaFactorPush) {
-        
         factor.verify(onStatusChange: { (status) in
-            self.handleStatus(status: status)
+            if status.factorResult == .waiting {
+                self.updateStatus(status: status)
+                DispatchQueue.main.asyncAfter(deadline:.now() + 5.0) {
+                    self.handlePushChallenge(factor: factor)
+                }
+            } else {
+                self.handleStatus(status: status)
+            }
         }, onError: { (error) in
             self.handleError(error)
-        }) { _ in
-            self.updateStatus(status: self.currentStatus)
-        }
+        })
     }
 
     func cancelTransaction() {

--- a/README.md
+++ b/README.md
@@ -397,8 +397,7 @@ Activates sms, call and token:software:totp factors to complete the enrollment p
 ```swift
 open func activateFactor(passCode: String?,
                          onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                         onError: @escaping (_ error: OktaError) -> Void,
-                         onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                         onError: @escaping (_ error: OktaError) -> Void)
 ```
 
 #### resendFactor
@@ -455,8 +454,7 @@ Verifies an answer to a question factor or OTP code for SMS/Call/Totp/Token fact
 open func verifyFactor(passCode: String?,
                        answerToSecurityQuestion: String?,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                       onError: @escaping (_ error: OktaError) -> Void)
 ```
 
 #### resendFactor
@@ -663,8 +661,7 @@ Enrolls a user with the Okta SMS factor and an SMS profile. A text message with 
 ```swift
 public func enroll(phoneNumber: String?,
                    onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                   onError: @escaping (OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/Enrollment/MFAEnrollmentViewController.swift#L103-L117)
 
@@ -675,8 +672,7 @@ Activates an SMS factor by verifying the OTP.
 ```swift
 public func activate(passCode: String?,
                      onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                     onError: @escaping (_ error: OktaError) -> Void,
-                     onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                     onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFASMSViewController.swift#L88-L98)
 
@@ -697,8 +693,7 @@ Verifies an enrolled SMS factor by verifying the OTP.
 ```swift
 public func verify(passCode: String?,
                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                   onError: @escaping (_ error: OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFASMSViewController.swift#L73-L84)
 
@@ -711,8 +706,7 @@ Enrolls a user with the Okta call factor and a Call profile. A voice call with a
 ```swift
 public func enroll(phoneNumber: String?,
                    onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                   onError: @escaping (OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/Enrollment/MFAEnrollmentViewController.swift#L103-L117)
 
@@ -723,8 +717,7 @@ Activates a call factor by verifying the OTP.
 ```swift
 public func activate(passCode: String?,
                      onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                     onError: @escaping (_ error: OktaError) -> Void,
-                     onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                     onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFASMSViewController.swift#L88-L98)
 
@@ -744,8 +737,7 @@ Verifies an enrolled call factor by verifying the OTP.
 ```swift
 public func verify(passCode: String?,
                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                   onError: @escaping (_ error: OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFASMSViewController.swift#L73-L84)
 
@@ -765,13 +757,11 @@ Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign
 #### [activate](https://developer.okta.com/docs/api/resources/authn/#activate-call-factor)
 
 Activation of push factors are asynchronous and must be polled for completion when the factorResult returns a WAITING status.
-**NOTE:** Polling is implemented by the SDK (default timer is 5 seconds), so you don't need to implement it in your code. SDK will notify your application about the last factor status via `onFactorStatusUpdate` closure.
 Activations have a short lifetime (minutes) and will TIMEOUT if they are not completed before the `expireAt` timestamp. Restart the activation process if the activation is expired.
 
 ```swift
 public func activate(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                     onError: @escaping (_ error: OktaError) -> Void,
-                     onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                     onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/Enrollment/MFActivatePushTotpViewController.swift#L48-L62)
 
@@ -807,14 +797,29 @@ Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign
 #### [verify](https://developer.okta.com/docs/api/resources/authn/#verify-push-factor)
 
 Sends an asynchronous push notification (challenge) to the device for the user to approve or reject. The `factorResult` for the transaction will have a result of WAITING, SUCCESS, REJECTED, or TIMEOUT.
-**NOTE:** Polling is implemented by the SDK (default interval is 5 seconds), so you don't need to implement it in your code. SDK will notify your application about the last factor status via `onFactorStatusUpdate` closure.
 
 ```swift
 public func verify(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                   onError: @escaping (_ error: OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (_ error: OktaError) -> Void)
 ```
-Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFAPushViewController.swift#L44-L57)
+Implement polling logic in order to get updates for the push factor result.
+**NOTE** Don't call `verify` function too often, keep polling interval within 3-5 seconds to not cause extra load on the server
+Example of polling logic:
+```swift
+func handlePushChallenge(factor: OktaFactorPush) {
+    factor.verify(onStatusChange: { (status) in
+        if status.factorResult == .waiting {
+            DispatchQueue.main.asyncAfter(deadline:.now() + 5.0) {
+                self.handlePushChallenge(factor: factor)
+            }
+        } else {
+            self.handleStatus(status: status)
+        }
+    }, onError: { (error) in
+        self.handleError(error)
+    })
+}
+```
 
 ### OktaFactorTotp
 
@@ -835,8 +840,7 @@ Activates a token:software:totp factor by verifying the OTP (passcode).
 ```swift
 public func activate(passCode: String,
                      onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                     onError: @escaping (_ error: OktaError) -> Void,
-                     onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                     onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/Enrollment/MFActivatePushTotpViewController.swift#L75-L90)
 
@@ -858,8 +862,7 @@ Verifies an OTP for a token:software:totp factor.
 ```swift
 public func verify(passCode: String,
                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                   onError: @escaping (_ error: OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (_ error: OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFATOTPViewController.swift#L39-L50)
 
@@ -895,8 +898,7 @@ Selects a question factor from the list of required factors and verifies the ans
 ```swift
 public func select(answerToSecurityQuestion: String,
                    onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                   onError: @escaping (OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFAViewController.swift#L65-L71)
 
@@ -907,8 +909,7 @@ Verifies an answer to a question factor.
 ```swift
 public func verify(answerToSecurityQuestion: String,
                    onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                   onError: @escaping (OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (OktaError) -> Void)
 ```
 Sample app [example](https://github.com/okta/samples-ios/blob/master/custom-sign-in/OktaNativeLogin/MFA/MFASecurityQuestionViewController.swift#L36-L47)
 
@@ -943,8 +944,7 @@ Verifies a passcode to a token factor.
 ```swift
 public func verify(passCode: String,
                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                   onError: @escaping (_ error: OktaError) -> Void,
-                   onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                   onError: @escaping (_ error: OktaError) -> Void)
 ```
 
 ### OktaFactorOther
@@ -959,8 +959,7 @@ Sends arbitrary `kayValuePayload` body in the https request.
 public func sendRequest(with link: LinksResponse.Link,
                         keyValuePayload: Dictionary<String, Any>,
                         onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                        onError: @escaping (OktaError) -> Void,
-                        onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil)
+                        onError: @escaping (OktaError) -> Void)
 ```
 
 

--- a/Source/Factors/OktaFactor.swift
+++ b/Source/Factors/OktaFactor.swift
@@ -15,8 +15,7 @@ import Foundation
 public protocol OktaFactorResultProtocol: class {
     func handleFactorServerResponse(response: OktaAPIRequest.Result,
                                     onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                    onError: @escaping (_ error: OktaError) -> Void,
-                                    onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?)
+                                    onError: @escaping (_ error: OktaError) -> Void)
 }
 
 open class OktaFactor {
@@ -152,8 +151,7 @@ open class OktaFactor {
     public func verify(passCode: String?,
                        answerToSecurityQuestion: String?,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (_ error: OktaError) -> Void) {
         guard canVerify() else {
             onError(OktaError.wrongStatus("Can't find 'verify' link in response"))
             return
@@ -163,14 +161,12 @@ open class OktaFactor {
                           answer: answerToSecurityQuestion,
                           passCode: passCode,
                           onStatusChange: onStatusChange,
-                          onError: onError,
-                          onFactorStatusUpdate: onFactorStatusUpdate)
+                          onError: onError)
     }
 
     public func activate(passCode: String?,
                          onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                         onError: @escaping (_ error: OktaError) -> Void,
-                         onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                         onError: @escaping (_ error: OktaError) -> Void) {
         guard canActivate() else {
             onError(OktaError.wrongStatus("Can't find 'activate' link in response"))
             return
@@ -180,8 +176,7 @@ open class OktaFactor {
                           answer: nil,
                           passCode: passCode,
                           onStatusChange: onStatusChange,
-                          onError: onError,
-                          onFactorStatusUpdate: onFactorStatusUpdate)
+                          onError: onError)
     }
 
     public func enroll(questionId: String?,
@@ -207,8 +202,7 @@ open class OktaFactor {
                               completion: { result in
                                 self.handleServerResponse(response: result,
                                                           onStatusChange:  onStatusChange,
-                                                          onError: onError,
-                                                          onFactorStatusUpdate: nil)
+                                                          onError: onError)
         })
     }
 
@@ -223,8 +217,7 @@ open class OktaFactor {
                           answer: nil,
                           passCode: nil,
                           onStatusChange: onStatusChange,
-                          onError: onError,
-                          onFactorStatusUpdate: nil)
+                          onError: onError)
     }
 
     var stateToken: String
@@ -241,8 +234,7 @@ open class OktaFactor {
                       answer: String?,
                       passCode: String?,
                       onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                      onError: @escaping (_ error: OktaError) -> Void,
-                      onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                      onError: @escaping (_ error: OktaError) -> Void) {
             restApi?.verifyFactor(with: link,
                                   stateToken: stateToken,
                                   answer: answer,
@@ -252,22 +244,19 @@ open class OktaFactor {
                                   completion:  { result in
                                     self.handleServerResponse(response: result,
                                                               onStatusChange: onStatusChange,
-                                                              onError: onError,
-                                                              onFactorStatusUpdate: onFactorStatusUpdate)
+                                                              onError: onError)
         })
     }
 
     func handleServerResponse(response: OktaAPIRequest.Result,
                               onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                              onError: @escaping (_ error: OktaError) -> Void,
-                              onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                              onError: @escaping (_ error: OktaError) -> Void) {
         if cancelled {
             return
         }
 
         self.responseDelegate?.handleFactorServerResponse(response: response,
                                                           onStatusChange: onStatusChange,
-                                                          onError: onError,
-                                                          onFactorStatusUpdate: onFactorStatusUpdate)
+                                                          onError: onError)
     }
 }

--- a/Source/Factors/OktaFactorCall.swift
+++ b/Source/Factors/OktaFactorCall.swift
@@ -34,13 +34,11 @@ open class OktaFactorCall : OktaFactor {
 
     public func verify(passCode: String,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
                      onStatusChange: onStatusChange,
-                     onError: onError,
-                     onFactorStatusUpdate: onFactorStatusUpdate)
+                     onError: onError)
     }
 
     // MARK: - Internal

--- a/Source/Factors/OktaFactorOther.swift
+++ b/Source/Factors/OktaFactorOther.swift
@@ -17,16 +17,14 @@ open class OktaFactorOther : OktaFactor {
     public func sendRequest(with link: LinksResponse.Link,
                             keyValuePayload: Dictionary<String, Any>,
                             onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                            onError: @escaping (OktaError) -> Void,
-                            onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                            onError: @escaping (OktaError) -> Void) {
         self.restApi?.sendApiRequest(with: link,
                                      bodyParams: keyValuePayload,
                                      method: .post,
                                      completion: { result in
                                         self.handleServerResponse(response: result,
                                                                   onStatusChange: onStatusChange,
-                                                                  onError: onError,
-                                                                  onFactorStatusUpdate: onFactorStatusUpdate)
+                                                                  onError: onError)
         })
     }
 

--- a/Source/Factors/OktaFactorPush.swift
+++ b/Source/Factors/OktaFactorPush.swift
@@ -141,19 +141,16 @@ open class OktaFactorPush : OktaFactor {
     }
 
     public func activate(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                         onError: @escaping (_ error: OktaError) -> Void,
-                         onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
-        super.activate(passCode: nil, onStatusChange: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
+                         onError: @escaping (_ error: OktaError) -> Void) {
+        super.activate(passCode: nil, onStatusChange: onStatusChange, onError: onError)
     }
 
     public func verify(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: nil,
                      answerToSecurityQuestion: nil,
                      onStatusChange: onStatusChange,
-                     onError: onError,
-                     onFactorStatusUpdate: onFactorStatusUpdate)
+                     onError: onError)
     }
 
     // MARK: - Internal

--- a/Source/Factors/OktaFactorQuestion.swift
+++ b/Source/Factors/OktaFactorQuestion.swift
@@ -57,8 +57,7 @@ open class OktaFactorQuestion : OktaFactor {
 
     public func select(answerToSecurityQuestion: String,
                        onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                       onError: @escaping (OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (OktaError) -> Void) {
         guard canSelect() else {
             onError(OktaError.wrongStatus("Can't find 'verify' link in response"))
             return
@@ -68,19 +67,16 @@ open class OktaFactorQuestion : OktaFactor {
                           answer: answerToSecurityQuestion,
                           passCode: nil,
                           onStatusChange: onStatusChange,
-                          onError: onError,
-                          onFactorStatusUpdate: onFactorStatusUpdate)
+                          onError: onError)
     }
 
     public func verify(answerToSecurityQuestion: String,
                        onStatusChange: @escaping (OktaAuthStatus) -> Void,
-                       onError: @escaping (OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (OktaError) -> Void) {
         super.verify(passCode: nil,
                      answerToSecurityQuestion: answerToSecurityQuestion,
                      onStatusChange: onStatusChange,
-                     onError: onError,
-                     onFactorStatusUpdate: onFactorStatusUpdate)
+                     onError: onError)
     }
 
     // MARK: - Internal

--- a/Source/Factors/OktaFactorSms.swift
+++ b/Source/Factors/OktaFactorSms.swift
@@ -34,13 +34,11 @@ open class OktaFactorSms : OktaFactor {
 
     public func verify(passCode: String,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
                      onStatusChange: onStatusChange,
-                     onError: onError,
-                     onFactorStatusUpdate: onFactorStatusUpdate)
+                     onError: onError)
     }
 
     // MARK: - Internal

--- a/Source/Factors/OktaFactorToken.swift
+++ b/Source/Factors/OktaFactorToken.swift
@@ -44,19 +44,16 @@ open class OktaFactorToken : OktaFactor {
                        onError: @escaping (OktaError) -> Void) {
         self.verify(passCode: passCode,
                     onStatusChange: onStatusChange,
-                    onError: onError,
-                    onFactorStatusUpdate: nil)
+                    onError: onError)
     }
     
     public func verify(passCode: String,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
                      onStatusChange: onStatusChange,
-                     onError: onError,
-                     onFactorStatusUpdate: onFactorStatusUpdate)
+                     onError: onError)
     }
 
     // MARK: - Internal

--- a/Source/Factors/OktaFactorTotp.swift
+++ b/Source/Factors/OktaFactorTotp.swift
@@ -45,9 +45,8 @@ open class OktaFactorTotp : OktaFactor {
 
     public func activate(passCode: String,
                          onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                         onError: @escaping (_ error: OktaError) -> Void,
-                         onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
-        super.activate(passCode: passCode, onStatusChange: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
+                         onError: @escaping (_ error: OktaError) -> Void) {
+        super.activate(passCode: passCode, onStatusChange: onStatusChange, onError: onError)
     }
 
     public func select(passCode: String,
@@ -57,19 +56,16 @@ open class OktaFactorTotp : OktaFactor {
                           answer: nil,
                           passCode: passCode,
                           onStatusChange: onStatusChange,
-                          onError: onError,
-                          onFactorStatusUpdate: nil)
+                          onError: onError)
     }
     
     public func verify(passCode: String,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                       onError: @escaping (_ error: OktaError) -> Void,
-                       onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                       onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
                      onStatusChange: onStatusChange,
-                     onError: onError,
-                     onFactorStatusUpdate: onFactorStatusUpdate)
+                     onError: onError)
     }
 
     // MARK: - Internal

--- a/Source/Statuses/OktaAuthStatusFactorChallenge.swift
+++ b/Source/Statuses/OktaAuthStatusFactorChallenge.swift
@@ -41,12 +41,6 @@ open class OktaAuthStatusFactorChallenge : OktaAuthStatus {
         return createdFactor
     }()
 
-    open var factorResult: OktaAPISuccessResponse.FactorResult? {
-        get {
-            return model.factorResult
-        }
-    }
-
     open func canVerify() -> Bool {
         return factor.canVerify()
     }
@@ -59,16 +53,18 @@ open class OktaAuthStatusFactorChallenge : OktaAuthStatus {
         return true
     }
 
+    open func canPoll() -> Bool {
+        return model.links?.next?.name == "poll" || factor.type == .push
+    }
+
     open func verifyFactor(passCode: String?,
                            answerToSecurityQuestion: String?,
                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                           onError: @escaping (_ error: OktaError) -> Void,
-                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                           onError: @escaping (_ error: OktaError) -> Void) {
         self.factor.verify(passCode: passCode,
                            answerToSecurityQuestion: answerToSecurityQuestion,
                            onStatusChange: onStatusChange,
-                           onError: onError,
-                           onFactorStatusUpdate: onFactorStatusUpdate)
+                           onError: onError)
     }
 
     open func resendFactor(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
@@ -88,11 +84,11 @@ open class OktaAuthStatusFactorChallenge : OktaAuthStatus {
         }
 
         self.restApi.perform(link: link,
-                         stateToken: stateToken,
-                         completion: { result in
-                            self.handleServerResponse(result,
-                                                      onStatusChanged: onStatusChange,
-                                                      onError: onError)
+                             stateToken: stateToken,
+                             completion: { result in
+                                self.handleServerResponse(result,
+                                                          onStatusChanged: onStatusChange,
+                                                          onError: onError)
         })
     }
 
@@ -108,9 +104,8 @@ open class OktaAuthStatusFactorChallenge : OktaAuthStatus {
 extension OktaAuthStatusFactorChallenge: OktaFactorResultProtocol {
     public func handleFactorServerResponse(response: OktaAPIRequest.Result,
                                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                           onError: @escaping (_ error: OktaError) -> Void,
-                                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
-        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
+                                           onError: @escaping (_ error: OktaError) -> Void) {
+        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError)
     }
 }
 

--- a/Source/Statuses/OktaAuthStatusFactorEnroll.swift
+++ b/Source/Statuses/OktaAuthStatusFactorEnroll.swift
@@ -101,8 +101,7 @@ open class OktaAuthStatusFactorEnroll : OktaAuthStatus {
 extension OktaAuthStatusFactorEnroll: OktaFactorResultProtocol {
     public func handleFactorServerResponse(response: OktaAPIRequest.Result,
                                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                           onError: @escaping (_ error: OktaError) -> Void,
-                                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
-        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
+                                           onError: @escaping (_ error: OktaError) -> Void) {
+        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError)
     }
 }

--- a/Source/Statuses/OktaAuthStatusFactorEnrollActivate.swift
+++ b/Source/Statuses/OktaAuthStatusFactorEnrollActivate.swift
@@ -47,12 +47,6 @@ open class OktaAuthStatusFactorEnrollActivate : OktaAuthStatus {
     
     public let activateLink: LinksResponse.Link
 
-    open var factorResult: OktaAPISuccessResponse.FactorResult? {
-        get {
-            return model.factorResult
-        }
-    }
-
     open func canResend() -> Bool {
         guard model.links?.resend != nil else {
             return false
@@ -61,14 +55,16 @@ open class OktaAuthStatusFactorEnrollActivate : OktaAuthStatus {
         return true
     }
 
+    open func canPoll() -> Bool {
+        return model.links?.next?.name == "poll" || factor.type == .push
+    }
+
     open func activateFactor(passCode: String?,
                              onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                             onError: @escaping (_ error: OktaError) -> Void,
-                             onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                             onError: @escaping (_ error: OktaError) -> Void) {
         self.factor.activate(passCode: passCode,
                              onStatusChange: onStatusChange,
-                             onError: onError,
-                             onFactorStatusUpdate: onFactorStatusUpdate)
+                             onError: onError)
     }
 
     open func resendFactor(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
@@ -108,8 +104,7 @@ open class OktaAuthStatusFactorEnrollActivate : OktaAuthStatus {
 extension OktaAuthStatusFactorEnrollActivate: OktaFactorResultProtocol {
     public func handleFactorServerResponse(response: OktaAPIRequest.Result,
                                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                           onError: @escaping (_ error: OktaError) -> Void,
-                                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
-        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
+                                           onError: @escaping (_ error: OktaError) -> Void) {
+        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError)
     }
 }

--- a/Source/Statuses/OktaAuthStatusFactorRequired.swift
+++ b/Source/Statuses/OktaAuthStatusFactorRequired.swift
@@ -64,8 +64,7 @@ open class OktaAuthStatusFactorRequired : OktaAuthStatus {
 extension OktaAuthStatusFactorRequired: OktaFactorResultProtocol {
     public func handleFactorServerResponse(response: OktaAPIRequest.Result,
                                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
-                                           onError: @escaping (_ error: OktaError) -> Void,
-                                           onFactorStatusUpdate: ((_ state: OktaAPISuccessResponse.FactorResult) -> Void)?) {
-        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError, onFactorStatusUpdate: onFactorStatusUpdate)
+                                           onError: @escaping (_ error: OktaError) -> Void) {
+        self.handleServerResponse(response, onStatusChanged: onStatusChange, onError: onError)
     }
 }

--- a/Source/Statuses/OktaAuthStatusRecoveryChallenge.swift
+++ b/Source/Statuses/OktaAuthStatusRecoveryChallenge.swift
@@ -31,12 +31,6 @@ open class OktaAuthStatusRecoveryChallenge : OktaAuthStatus {
         }
     }
 
-    open var factorResult: OktaAPISuccessResponse.FactorResult? {
-        get {
-            return model.factorResult
-        }
-    }
-
     open func canVerify() -> Bool {
         guard model.links?.next != nil else {
             return false

--- a/Tests/Factors/OktaFactorOtherTests.swift
+++ b/Tests/Factors/OktaFactorOtherTests.swift
@@ -40,10 +40,6 @@ class OktaFactorOtherTests: OktaFactorTestCase {
             onError: { error in
                 XCTFail(error.localizedDescription)
                 ex.fulfill()
-            },
-            onFactorStatusUpdate: { factorResult in
-                XCTFail("Unexpected call of onFactorStatusUpdate!")
-                ex.fulfill()
             }
         )
         
@@ -74,10 +70,6 @@ class OktaFactorOtherTests: OktaFactorTestCase {
             },
             onError: { error in
                 XCTAssertEqual(delegate.error?.localizedDescription, error.localizedDescription)
-                ex.fulfill()
-            },
-            onFactorStatusUpdate: { factorResult in
-                XCTFail("Unexpected call of onFactorStatusUpdate!")
                 ex.fulfill()
             }
         )

--- a/Tests/Mocks/OktaAuthStatusResponseHandlerMock.swift
+++ b/Tests/Mocks/OktaAuthStatusResponseHandlerMock.swift
@@ -23,7 +23,7 @@ class OktaAuthStatusResponseHandlerMock: OktaAuthStatusResponseHandler {
     var response: OktaAPIRequest.Result?
     
     init(changedStatus: OktaAuthStatus? = nil, error: OktaError? = nil, statusUpdate: OktaAPISuccessResponse.FactorResult? = nil) {
-        super.init(pollInterval: 5.0)
+        super.init()
         self.changedStatus = changedStatus
         self.error = error
         self.statusUpdate = statusUpdate
@@ -32,8 +32,7 @@ class OktaAuthStatusResponseHandlerMock: OktaAuthStatusResponseHandler {
     override func handleServerResponse(_ response: OktaAPIRequest.Result,
                               currentStatus: OktaAuthStatus,
                               onStatusChanged: @escaping (OktaAuthStatus) -> Void,
-                              onError: @escaping (OktaError) -> Void,
-                              onFactorStatusUpdate: ((OktaAPISuccessResponse.FactorResult) -> Void)? = nil) {
+                              onError: @escaping (OktaError) -> Void) {
         self.handleResponseCalled = true
         self.response = response
         
@@ -44,11 +43,6 @@ class OktaAuthStatusResponseHandlerMock: OktaAuthStatusResponseHandler {
         
         if let error = error {
             onError(error)
-            return
-        }
-        
-        if let statusUpdate = statusUpdate {
-            onFactorStatusUpdate?(statusUpdate)
             return
         }
     }

--- a/Tests/Mocks/OktaFactorResultProtocolMock.swift
+++ b/Tests/Mocks/OktaFactorResultProtocolMock.swift
@@ -24,8 +24,7 @@ class OktaFactorResultProtocolMock: OktaFactorResultProtocol {
     func handleFactorServerResponse(
         response: OktaAPIRequest.Result,
         onStatusChange: @escaping (OktaAuthStatus) -> Void,
-        onError: @escaping (OktaError) -> Void,
-        onFactorStatusUpdate: ((OktaAPISuccessResponse.FactorResult) -> Void)?)
+        onError: @escaping (OktaError) -> Void)
     {
         self.response = response
         
@@ -33,8 +32,6 @@ class OktaFactorResultProtocolMock: OktaFactorResultProtocol {
             onStatusChange(changedStatus)
         } else if let error = error {
             onError(error)
-        } else if let statusUpdate = statusUpdate {
-            onFactorStatusUpdate?(statusUpdate)
         }
     }
 }

--- a/Tests/Statuses/OktaAuthStatusTests.swift
+++ b/Tests/Statuses/OktaAuthStatusTests.swift
@@ -205,67 +205,6 @@ class OktaAuthStatusTests: XCTestCase {
         XCTAssertTrue(status.apiMock.cancelTransactionCalled)
     }
     
-    // MARK: - poll
-    
-    func testPoll() {
-        guard let response = TestResponse.MFA_CHALLENGE_WAITING_PUSH.parse(),
-              let status = try? OktaAuthStatusFactorChallenge(currentState: createUnathenticatedStatus(), model: response) else {
-              XCTFail()
-              return
-        }
-        
-        status.setupApiMockResponse(.SUCCESS)
-        
-        let ex = expectation(description: "Operation should succeed!")
-        
-        status.poll(
-            onStatusChange: { status in
-                XCTAssertEqual(AuthStatus.success, status.statusType)
-                ex.fulfill()
-            },
-            onError: { error in
-                XCTFail(error.localizedDescription)
-                ex.fulfill()
-            }
-        )
-        
-        waitForExpectations(timeout: 5.0)
-
-        XCTAssertTrue(status.apiMock.verifyFactorCalled)
-        XCTAssertEqual(response.links?.next?.href, status.apiMock.factorVerificationLink?.href)
-    }
-    
-    func testPoll_ApiError() {
-        guard let response = TestResponse.MFA_CHALLENGE_WAITING_PUSH.parse(),
-              let status = try? OktaAuthStatusFactorChallenge(currentState: createUnathenticatedStatus(), model: response) else {
-              XCTFail()
-              return
-        }
-        
-        status.setupApiMockFailure()
-        
-        let ex = expectation(description: "Operation should fail!")
-        
-        status.poll(
-            onStatusChange: { status in
-                XCTFail("Unexpected status change!")
-                ex.fulfill()
-            },
-            onError: { error in
-                XCTAssertEqual(
-                    "Server responded with error: Authentication failed",
-                    error.localizedDescription
-                )
-                ex.fulfill()
-            }
-        )
-        
-        waitForExpectations(timeout: 5.0)
-
-        XCTAssertTrue(status.apiMock.verifyFactorCalled)
-        XCTAssertEqual(response.links?.next?.href, status.apiMock.factorVerificationLink?.href)
-    }
-    
     // MARK: - fetchStatus
     
     func testFetchStatus() {


### PR DESCRIPTION
### Problem Analysis (Technical)
Polling doesn't stop when state machine transits to the previous state

### Solution (Technical)
Auto polling logic is a bit confusing and error prone. It is better to delegate polling to application space as it will be really easy to implement

### Affected Components
Factors
Statuses
StatusHandler

### Tests
Updated
