### PR TITLE
OKTA-237473-AuthN iOS SDK: SDK sends incorrect version in User-Agent header field

### DIFF
--- a/Source/RestAPI/Utils.swift
+++ b/Source/RestAPI/Utils.swift
@@ -16,8 +16,12 @@ import Foundation
 import UIKit
 #endif
 
+public func sdkVersion() -> String {
+    return "2.0.0"
+}
+
 internal func buildUserAgent() -> String {
-    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "?"
+    let version = sdkVersion()
     let device = "Device/\(deviceModel())"
     #if os(iOS)
     let os = "iOS/\(UIDevice.current.systemVersion)"


### PR DESCRIPTION
### Problem Analysis (Technical)
App version is reported instead for sdk version

### Solution (Technical)
Hardcode current sdk version
