### PR TITLE
Github issue: passwordExpireDays not decoded into model from response

### DIFF
--- a/Source/DomainObjects/OktaModels.swift
+++ b/Source/DomainObjects/OktaModels.swift
@@ -271,7 +271,7 @@ public struct EmbeddedResponse: Codable {
     public enum Policy: Codable {
         /// A subset of policy settings of the Sign-On Policy or App Sign-On Policy.
         public struct RememberDevice: Codable {
-            public let allowRememberDevice: Bool?
+            public let allowRememberDevice: Bool
             public let rememberDeviceByDefault: Bool?
             public let rememberDeviceLifetimeInMinutes: Int?
         }
@@ -291,11 +291,17 @@ public struct EmbeddedResponse: Codable {
                 public let minUpperCase: Int?
                 public let minNumber: Int?
                 public let minSymbol: Int?
-                public let excludeUsername: Bool
+                public let excludeUsername: Bool?
+            }
+
+            public struct PasswordAge: Codable {
+                public let minAgeMinutes: Int?
+                public let historyCount: Int?
             }
 
             public let expiration: PasswordExpiration?
             public let complexity: PasswordComplexity?
+            public let age: PasswordAge?
         }
     
         case rememberDevice(RememberDevice)

--- a/Tests/Resources/PASSWORD_WARN
+++ b/Tests/Resources/PASSWORD_WARN
@@ -24,7 +24,12 @@
         "minLowerCase": 1,
         "minUpperCase": 1,
         "minNumber": 1,
-        "minSymbol": 0
+        "minSymbol": 0,
+        "excludeUsername": true
+      },
+      "age":{
+        "minAgeMinutes":0,
+        "historyCount":0
       }
     }
   },

--- a/Tests/Statuses/OktaAuthStatusPasswordWarningTests.swift
+++ b/Tests/Statuses/OktaAuthStatusPasswordWarningTests.swift
@@ -22,6 +22,20 @@ class OktaAuthStatusPasswordWarningTests: XCTestCase {
             return
         }
         
+        XCTAssertNotNil(status.model.expirationDate)
+        XCTAssertNotNil(status.model.links?.next)
+        XCTAssertNotNil(status.model.links?.skip)
+        XCTAssertNotNil(status.model.links?.cancel)
+        XCTAssertNotNil(status.model.embedded)
+        XCTAssertNotNil(status.model.embedded?.policy)
+        if case .password(let password) = status.model.embedded?.policy {
+            XCTAssertNotNil(password.complexity)
+            XCTAssertNotNil(password.expiration)
+            XCTAssertNotNil(password.age)
+        } else {
+            XCTFail("Failed to parse policy.")
+        }
+        
         status.setupApiMockResponse(.SUCCESS)
         
         let ex = expectation(description: "Callback is expected!")

--- a/Tests/Statuses/OktaAuthStatusPasswordWarningTests.swift
+++ b/Tests/Statuses/OktaAuthStatusPasswordWarningTests.swift
@@ -28,7 +28,7 @@ class OktaAuthStatusPasswordWarningTests: XCTestCase {
         XCTAssertNotNil(status.model.links?.cancel)
         XCTAssertNotNil(status.model.embedded)
         XCTAssertNotNil(status.model.embedded?.policy)
-        if case .password(let password) = status.model.embedded?.policy {
+        if case .password(let password)? = status.model.embedded?.policy {
             XCTAssertNotNil(password.complexity)
             XCTAssertNotNil(password.expiration)
             XCTAssertNotNil(password.age)


### PR DESCRIPTION
https://github.com/okta/okta-auth-swift/issues/100

### Problem Analysis (Technical)
To identify whether policy set contains PasswordPolicy or RememberDevicePolicy sub-sets, sdk does the following:
1. Tries to decode RememberDevicePolicy sub-set
2. If 1 fails then tries to decode PasswordPolicy sub-set
Since RememberDevicePolicy class consists of only optional values decoder parses it with empty values and doesn't take into account presence of PasswordPolicy

### Solution (Technical)
Make `allowRememberDevice` field in `RememberDevicePolicy` mandatory. According to the current version of the spec this value is non-nullable

### Affected Components
`Policy` class

### Tests
Added
