### PR TITLE
Add email property to EmbeddedResponse.Factor.Profile struct

### DIFF
--- a/Source/DomainObjects/OktaModels.swift
+++ b/Source/DomainObjects/OktaModels.swift
@@ -158,6 +158,7 @@ public struct EmbeddedResponse: Codable {
         
         public struct Profile: Codable {
             public let phoneNumber: String?
+            public let email: String?
             public let question: String?
             public let questionText: String?
             public let credentialId: String?


### PR DESCRIPTION
Since the (masked) email comes back in the JSON from OKTA, it can be mapped when present to have it available for display to the user in an MFA context.

### Problem Analysis (Technical)
When the user profile is returned from OKTA, email is part of it, depending on the context.  This is currently not mapped to the struct, and there is no good way to add it via extension.

### Solution (Technical)
Add email property to Profile struct

### Affected Components


### Steps to reproduce:
Initiate email MFA 

Actual result:
No email property is available to display what email address the MFA email is being sent to.

Expected result:
I would expect to show to the user what email address the MFA code is being sent to.
