### PR TITLE
If enrolling an sms, allow updating the verified phone #

### DIFF
--- a/Source/RestAPI/OktaAPI.swift
+++ b/Source/RestAPI/OktaAPI.swift
@@ -235,7 +235,11 @@ open class OktaAPI {
         let req = buildBaseRequest(completion: completion)
         req.baseURL = link.href
         req.method = .post
-        req.urlParams = [:]
+        if (factor.factorType == .sms) {
+            req.urlParams = ["updatePhone":"true"]
+        } else {
+            req.urlParams = [:]
+        }
         req.bodyParams = ["stateToken": stateToken]
         req.bodyParams?["factorType"] = factor.factorType.rawValue
         req.bodyParams?["provider"] = factor.provider?.rawValue


### PR DESCRIPTION
### Problem Analysis (Technical)
Users were locked to only being able to use one phone number for MFA SMS. You get a 400 from the authn api when providing a different phone number than the verified phone during MFA SMS enrollment. 

### Solution (Technical)
On an sms mfa enrollment request add the updatePhone query parameter

### Affected Components
OktaAPI enrollFactor method

### Steps to reproduce:
Enroll MFA SMS for a user, reset MFA SMS. Enroll in MFA SMS again with a different phone number.

Actual result:
You get a 400 and can only do MFA SMS with the first verified phone number
Expected result:
You can enroll with a different phone number

### Tests
