### PR TITLE
Added ability to pass device token and device fingerprint

### DIFF
--- a/Source/OktaAuthSdk.swift
+++ b/Source/OktaAuthSdk.swift
@@ -17,12 +17,16 @@ public class OktaAuthSdk {
     public class func authenticate(with url: URL,
                                    username: String,
                                    password: String?,
+                                   deviceToken: String?,
+                                   deviceFingerprint: String?,
                                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                                    onError: @escaping (_ error: OktaError) -> Void) {
         
         let unauthenticatedStatus = OktaAuthStatusUnauthenticated(oktaDomain: url)
         unauthenticatedStatus.authenticate(username: username,
                                            password: password ?? "",
+                                           deviceToken: deviceToken ?? "",
+                                           deviceFingerprint: deviceFingerprint ?? "",
                                            onStatusChange:onStatusChange,
                                            onError:onError)
     }

--- a/Source/Statuses/OktaAuthStatusUnauthenticated.swift
+++ b/Source/Statuses/OktaAuthStatusUnauthenticated.swift
@@ -21,12 +21,15 @@ open class OktaAuthStatusUnauthenticated : OktaAuthStatus {
 
     open func authenticate(username: String,
                            password: String,
+                           deviceToken: String,
+                           deviceFingerprint: String,
                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                            onError: @escaping (_ error: OktaError) -> Void) {
 
         restApi.primaryAuthentication(username: username,
                                       password: password,
-                                      deviceFingerprint: nil)
+                                      deviceToken: deviceToken,
+                                      deviceFingerprint: deviceFingerprint)
         { result in
             self.handleServerResponse(result,
                                       onStatusChanged: onStatusChange,


### PR DESCRIPTION
Added ability to pass device token and device fingerprint from app that references this SDK.

### Problem Analysis (Technical)
For "global sign-on policy - prompt for MFA once per device" support, there was no way to specify the device token in this SDK.  While the web counterpart was working as expected, prompting users only on a new device/browser, iOS users had to complete MFA on every sign-in.  

### Solution (Technical)
Since this SDK already supports passing the device token to the Okta API, but there was no way to pass it from an app that references the SDK, I added a parameter that allows this.  I also added the device fingerprint parameter even though we ended up not using it for our configuration (I believe the fingerprint affects Behavior Detection).

I am particularly interested in getting feedback from Okta here.  I have maintained a forked repo to implement this missing piece for us.  During our implementation phase, we reached out to our implementation specialist who recommended that we add this "feature" ourselves.
The reason I am posting this now is that we are experiencing very isolated issues with certain iOS users.  A ticket was opened with Okta Support (case#00740227), but because we are unable to reproduce the issue on one of our devices, I decided to reach out via this PR to see if anybody might have an idea whether this "feature" is not fully supported on iOS, and was left out so far for that exact reason.  

### Affected Components
OktaAuthSdk.authenticate()
OktaAuthStatusUnauthenticated.authenticate()

### Steps to reproduce:
N/A - missing "feature"

Actual result:
N/A - missing "feature"

Expected result:
N/A - missing "feature"

### Tests
