### PR TITLE
fix(format-date-locale)

### DIFF
--- a/Source/RestAPI/OktaAPIRequest.swift
+++ b/Source/RestAPI/OktaAPIRequest.swift
@@ -32,6 +32,7 @@ public class OktaAPIRequest {
         decoder = JSONDecoder()
         
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         decoder.dateDecodingStrategy = .formatted(formatter)
     }


### PR DESCRIPTION
- force locale "en_US_POSIX" DateFormatter

### Problem Analysis (Technical)
Date string does not match format expected by formatter.
ERROR: Authentication failed with error: responseSerializationError(Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "_embedded", intValue: nil), CodingKeys(stringValue: "user", intValue: nil), CodingKeys(stringValue: "passwordChanged", intValue: nil)], debugDescription: "Date string does not match format expected by formatter.", underlyingError: nil)), 1172 bytes)

### Solution (Technical)

dateFormatter.locale = Locale(identifier: "en_US_POSIX")
### Affected Components

Authentication
### Steps to reproduce:
Launch the Settings app.
Tap General.
Tap Date & Time.
Tap on the Off switch next to 24-Hour Time.

Actual result:
ERROR: Authentication failed with error: responseSerializationError(Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "_embedded", intValue: nil), CodingKeys(stringValue: "user", intValue: nil), CodingKeys(stringValue: "passwordChanged", intValue: nil)], debugDescription: "Date string does not match format expected by formatter.", underlyingError: nil)), 1172 bytes)
Expected result:
{"expiresAt":"2020-12-10T17:48:07.000Z","status":"SUCCESS","sessionToken":"20111A6A-hifqEsKRE1H657Hdf2D9EPz2NG1RJVI3pNckwmdofJQC-B","_embedded":{"user":{"id":"00uucbqzlv6jzxVS80h7","passwordChanged":"2020-10-28T23:48:34.000Z","profile":{"login":"rone.loza@gmail.com","firstName":"David","lastName":"Grande Castorena","locale":"en","timeZone":"America/Los_Angeles"}}},"_links":{"cancel":{"href":"","hints":{"allow":["POST"]}}}}
### Tests
