### PR TITLE
Add Remember Device support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 .build/
+.swiftpm
 
 # CocoaPods
 #

--- a/Example/OktaAuthNative Example.xcodeproj/project.pbxproj
+++ b/Example/OktaAuthNative Example.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		92BEAB922608A2FE0082BC3E /* OktaAuthNative.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92BEAB912608A2FE0082BC3E /* OktaAuthNative.framework */; };
+		92BEAB932608A2FE0082BC3E /* OktaAuthNative.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 92BEAB912608A2FE0082BC3E /* OktaAuthNative.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FAC5AEE821C7F9A600C3DC91 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC5AEE721C7F9A600C3DC91 /* AppDelegate.swift */; };
 		FAC5AEEA21C7F9A600C3DC91 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC5AEE921C7F9A600C3DC91 /* ViewController.swift */; };
 		FAC5AEED21C7F9A600C3DC91 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FAC5AEEB21C7F9A600C3DC91 /* Main.storyboard */; };
@@ -21,6 +23,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				92BEAB932608A2FE0082BC3E /* OktaAuthNative.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -28,6 +31,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		92BEAB912608A2FE0082BC3E /* OktaAuthNative.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OktaAuthNative.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAC5AEE421C7F9A600C3DC91 /* OktaAuthNative Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "OktaAuthNative Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAC5AEE721C7F9A600C3DC91 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FAC5AEE921C7F9A600C3DC91 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -42,17 +46,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				92BEAB922608A2FE0082BC3E /* OktaAuthNative.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		92BEAB902608A2FE0082BC3E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				92BEAB912608A2FE0082BC3E /* OktaAuthNative.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		FAC5AEDB21C7F9A600C3DC91 = {
 			isa = PBXGroup;
 			children = (
 				FAC5AEE621C7F9A600C3DC91 /* Source */,
 				FAC5AEE521C7F9A600C3DC91 /* Products */,
+				92BEAB902608A2FE0082BC3E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Example/OktaAuthNative Example.xcodeproj/xcshareddata/xcschemes/OktaAuthNative Example.xcscheme
+++ b/Example/OktaAuthNative Example.xcodeproj/xcshareddata/xcschemes/OktaAuthNative Example.xcscheme
@@ -27,28 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FA500E4421C7FCD800444B1D"
-               BuildableName = "OktaAuth iOS Tests.xctest"
-               BlueprintName = "OktaAuth iOS Tests"
-               ReferencedContainer = "container:../OktaAuth.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2FF5C86321D3BA1900EECA75"
-               BuildableName = "OktaAuth iOS Integration Tests.xctest"
-               BlueprintName = "OktaAuth iOS Integration Tests"
-               ReferencedContainer = "container:../OktaAuth.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -75,8 +53,28 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA500E4421C7FCD800444B1D"
+               BuildableName = "OktaAuth iOS Tests.xctest"
+               BlueprintName = "OktaAuth iOS Tests"
+               ReferencedContainer = "container:../OktaAuth.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2FF5C86321D3BA1900EECA75"
+               BuildableName = "OktaAuth iOS Integration Tests.xctest"
+               BlueprintName = "OktaAuth iOS Integration Tests"
+               ReferencedContainer = "container:../OktaAuth.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -98,8 +96,6 @@
             ReferencedContainer = "container:OktaAuthNative Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Source/Base.lproj/Main.storyboard
+++ b/Example/Source/Base.lproj/Main.storyboard
@@ -52,7 +52,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="fmh-12-dp1">
                                         <rect key="frame" x="0.0" y="120" width="295" height="31"/>
                                         <subviews>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k4W-FV-fBk">
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="k4W-FV-fBk">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
                                             </switch>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remember device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hPg-0q-vSF">

--- a/Example/Source/Base.lproj/Main.storyboard
+++ b/Example/Source/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SRH-bA-3Iu">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SRH-bA-3Iu">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,85 +16,109 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Z63-tr-VfQ">
-                                <rect key="frame" x="40" y="145" width="295" height="40"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="FW5-xZ-apV" userLabel="State Labels">
+                                <rect key="frame" x="40" y="84" width="94.5" height="20.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dAN-QU-rTh">
+                                        <rect key="frame" x="0.0" y="0.0" width="45" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bNp-x1-nJh">
+                                        <rect key="frame" x="53" y="0.0" width="41.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                        <color key="textColor" red="0.21129283308982849" green="0.48272740840911865" blue="0.73409742116928101" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="4vi-z2-0M6" userLabel="Text Fields">
+                                <rect key="frame" x="40" y="125" width="295" height="151"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="oleg.gnidets" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Z63-tr-VfQ">
+                                        <rect key="frame" x="0.0" y="0.0" width="295" height="40"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="40" id="GxG-hT-9tm"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="QWEqwe123!" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iBN-rf-b9P">
+                                        <rect key="frame" x="0.0" y="60" width="295" height="40"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                    </textField>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="fmh-12-dp1">
+                                        <rect key="frame" x="0.0" y="120" width="295" height="31"/>
+                                        <subviews>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k4W-FV-fBk">
+                                                <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
+                                            </switch>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remember device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hPg-0q-vSF">
+                                                <rect key="frame" x="61" y="0.0" width="234" height="31"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="GxG-hT-9tm"/>
+                                    <constraint firstItem="iBN-rf-b9P" firstAttribute="height" secondItem="Z63-tr-VfQ" secondAttribute="height" id="Wx1-Pg-TMG"/>
                                 </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iBN-rf-b9P">
-                                <rect key="frame" x="40" y="205" width="295" height="40"/>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ZA3-6h-7hG" userLabel="Buttons">
+                                <rect key="frame" x="97.5" y="296" width="180" height="120"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hqc-Ab-uE5">
+                                        <rect key="frame" x="20" y="0.0" width="140" height="50"/>
+                                        <color key="backgroundColor" white="0.95280393839999999" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="J65-bi-Jw7"/>
+                                            <constraint firstAttribute="height" constant="50" id="ziu-oG-JwR"/>
+                                        </constraints>
+                                        <state key="normal" title="Login"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="5"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="loginTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="MJQ-rd-pfq"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jCR-R9-x7L">
+                                        <rect key="frame" x="66" y="70" width="48" height="50"/>
+                                        <state key="normal" title="Cancel"/>
+                                        <connections>
+                                            <action selector="cancelTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="Lfz-Fy-5bQ"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="x4y-7k-pR6"/>
+                                    <constraint firstItem="jCR-R9-x7L" firstAttribute="height" secondItem="Hqc-Ab-uE5" secondAttribute="height" id="kKx-J0-rPY"/>
                                 </constraints>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hqc-Ab-uE5">
-                                <rect key="frame" x="117.5" y="265" width="140" height="50"/>
-                                <color key="backgroundColor" white="0.95280393839999999" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="140" id="J65-bi-Jw7"/>
-                                    <constraint firstAttribute="height" constant="50" id="ziu-oG-JwR"/>
-                                </constraints>
-                                <state key="normal" title="Login"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="5"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="loginTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="MJQ-rd-pfq"/>
-                                </connections>
-                            </button>
+                            </stackView>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="5YA-cW-bFe">
-                                <rect key="frame" x="131.5" y="280" width="20" height="20"/>
+                                <rect key="frame" x="125.5" y="311" width="20" height="20"/>
                             </activityIndicatorView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dAN-QU-rTh">
-                                <rect key="frame" x="40" y="104" width="45" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="State" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bNp-x1-nJh">
-                                <rect key="frame" x="93" y="104" width="41.5" height="21"/>
-                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                <color key="textColor" red="0.21129283308982849" green="0.48272740840911865" blue="0.73409742116928101" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jCR-R9-x7L">
-                                <rect key="frame" x="163.5" y="335" width="48" height="30"/>
-                                <state key="normal" title="Cancel"/>
-                                <connections>
-                                    <action selector="cancelTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="Lfz-Fy-5bQ"/>
-                                </connections>
-                            </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="Z63-tr-VfQ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="40" id="36h-Vn-Scz"/>
-                            <constraint firstItem="jCR-R9-x7L" firstAttribute="top" secondItem="Hqc-Ab-uE5" secondAttribute="bottom" constant="20" id="Bv0-zE-JdP"/>
-                            <constraint firstItem="5YA-cW-bFe" firstAttribute="centerY" secondItem="Hqc-Ab-uE5" secondAttribute="centerY" id="F7F-lX-0y2"/>
-                            <constraint firstItem="iBN-rf-b9P" firstAttribute="top" secondItem="Z63-tr-VfQ" secondAttribute="bottom" constant="20" id="FuD-No-N3b"/>
-                            <constraint firstItem="dAN-QU-rTh" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="40" id="LBR-9E-yi7"/>
-                            <constraint firstItem="jCR-R9-x7L" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="SUM-ug-NhT"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="iBN-rf-b9P" secondAttribute="trailing" constant="40" id="UBN-Yb-zi0"/>
-                            <constraint firstItem="dAN-QU-rTh" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="40" id="Vs1-Jb-7Fd"/>
-                            <constraint firstItem="Hqc-Ab-uE5" firstAttribute="top" secondItem="iBN-rf-b9P" secondAttribute="bottom" constant="20" id="Yd4-dn-qyj"/>
-                            <constraint firstItem="Z63-tr-VfQ" firstAttribute="top" secondItem="dAN-QU-rTh" secondAttribute="bottom" constant="20" id="gBs-u9-Hw3"/>
-                            <constraint firstItem="Hqc-Ab-uE5" firstAttribute="leading" secondItem="5YA-cW-bFe" secondAttribute="leading" constant="-14" id="hc6-kM-xDB"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Z63-tr-VfQ" secondAttribute="trailing" constant="40" id="hpK-rM-tF6"/>
-                            <constraint firstItem="Hqc-Ab-uE5" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="jd7-AI-bye"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bNp-x1-nJh" secondAttribute="trailing" constant="40" id="nx2-Vp-sh4"/>
-                            <constraint firstItem="bNp-x1-nJh" firstAttribute="leading" secondItem="dAN-QU-rTh" secondAttribute="trailing" constant="8" id="ph4-sN-jMO"/>
-                            <constraint firstItem="bNp-x1-nJh" firstAttribute="firstBaseline" secondItem="dAN-QU-rTh" secondAttribute="firstBaseline" id="s3m-bN-CUX"/>
-                            <constraint firstItem="iBN-rf-b9P" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="40" id="t1e-WI-1Gp"/>
+                            <constraint firstItem="ZA3-6h-7hG" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="97.5" id="1Me-SY-qrz"/>
+                            <constraint firstItem="FW5-xZ-apV" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="40" id="7si-0q-H6q"/>
+                            <constraint firstItem="4vi-z2-0M6" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="40" id="Crt-H3-c5I"/>
+                            <constraint firstItem="5YA-cW-bFe" firstAttribute="leading" secondItem="Hqc-Ab-uE5" secondAttribute="leading" constant="8" id="FSb-9o-lrn"/>
+                            <constraint firstItem="5YA-cW-bFe" firstAttribute="centerY" secondItem="Hqc-Ab-uE5" secondAttribute="centerY" id="GAC-Ah-1lY"/>
+                            <constraint firstItem="ZA3-6h-7hG" firstAttribute="top" secondItem="4vi-z2-0M6" secondAttribute="bottom" constant="20" id="IXC-Be-2mi"/>
+                            <constraint firstItem="4vi-z2-0M6" firstAttribute="top" secondItem="FW5-xZ-apV" secondAttribute="bottom" constant="20.5" id="KrE-RI-hMP"/>
+                            <constraint firstItem="4vi-z2-0M6" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="jko-hE-Q01"/>
+                            <constraint firstItem="FW5-xZ-apV" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="40" id="nWj-dO-sVl"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FW5-xZ-apV" secondAttribute="trailing" constant="32" id="srz-R4-2FN"/>
+                            <constraint firstItem="ZA3-6h-7hG" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="trr-8W-Jh6"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="bs5-H1-FQS">
                         <nil key="title"/>
@@ -123,6 +145,8 @@
                         <outlet property="cancelButton" destination="jCR-R9-x7L" id="KWk-gJ-yhA"/>
                         <outlet property="loginButton" destination="Hqc-Ab-uE5" id="Ghd-W7-8Rc"/>
                         <outlet property="passwordField" destination="iBN-rf-b9P" id="Xgk-rI-End"/>
+                        <outlet property="rememberContainer" destination="fmh-12-dp1" id="5wj-jC-Zuw"/>
+                        <outlet property="rememberSwitch" destination="k4W-FV-fBk" id="LBv-PH-4ie"/>
                         <outlet property="stateLabel" destination="bNp-x1-nJh" id="Gz9-MY-AmI"/>
                         <outlet property="usernameField" destination="Z63-tr-VfQ" id="BcO-xr-kc5"/>
                     </connections>
@@ -136,7 +160,7 @@
             <objects>
                 <navigationController id="SRH-bA-3Iu" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="tHC-R9-OQ8">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -22,13 +22,15 @@ class ViewController: UIViewController {
         self.updateStatus(status: nil)
     }
 
-    @IBOutlet private var stateLabel: UILabel!
-    @IBOutlet private var usernameField: UITextField!
-    @IBOutlet private var passwordField: UITextField!
-    @IBOutlet private var loginButton: UIButton!
-    @IBOutlet private var cancelButton: UIButton!
-    @IBOutlet private var activityIndicator: UIActivityIndicatorView!
-
+    @IBOutlet private weak var stateLabel: UILabel!
+    @IBOutlet private weak var usernameField: UITextField!
+    @IBOutlet private weak var passwordField: UITextField!
+    @IBOutlet private weak var loginButton: UIButton!
+    @IBOutlet private weak var cancelButton: UIButton!
+    @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet private weak var rememberContainer: UIStackView!
+    @IBOutlet private weak var rememberSwitch: UISwitch!
+    
     @IBAction private func loginTapped() {
         guard let username = usernameField.text,
             let password = passwordField.text else { return }
@@ -36,6 +38,7 @@ class ViewController: UIViewController {
         OktaAuthSdk.authenticate(with: URL(string: "https://{yourOktaDomain}")!,
                                  username: username,
                                  password: password,
+                                 deviceToken: makeDeviceToken(),
                                  onStatusChange: { authStatus in
                                     self.handleStatus(status: authStatus)
         },
@@ -127,6 +130,7 @@ class ViewController: UIViewController {
 
     func updateStatus(status: OktaAuthStatus?, factorResult: OktaAPISuccessResponse.FactorResult? = nil) {
         guard let status = status else {
+//            rememberSwitch.isOn = false
             stateLabel.text = "Unauthenticated"
             return
         }
@@ -145,8 +149,8 @@ class ViewController: UIViewController {
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         present(alert, animated: true, completion: nil)
 
-        self.loginButton.isEnabled = false
-        self.cancelButton.isEnabled = false
+//        self.loginButton.isEnabled = false
+//        self.cancelButton.isEnabled = false
     }
 
     func handleError(_ error: OktaError) {
@@ -188,6 +192,7 @@ class ViewController: UIViewController {
         factorRequiredStatus.availableFactors.forEach { factor in
             alert.addAction(UIAlertAction(title: factor.type.rawValue, style: .default, handler: { _ in
                 factorRequiredStatus.selectFactor(factor,
+                                                  rememberDevice: self.rememberSwitch.isOn,
                                                   onStatusChange: { status in
                     self.handleStatus(status: status)
                 },
@@ -275,6 +280,7 @@ class ViewController: UIViewController {
             alert.addTextField { $0.placeholder = "Code" }
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
                 guard let code = alert.textFields?[0].text else { return }
+                
                 status.activateFactor(passCode: code,
                                       onStatusChange: { status in
                                         self.handleStatus(status: status)
@@ -290,7 +296,8 @@ class ViewController: UIViewController {
         }
         else {
             if status.factorResult == nil || status.factorResult == .waiting {
-                status.activateFactor(passCode: nil, onStatusChange: { status in
+                status.activateFactor(passCode: nil,
+                                      onStatusChange: { status in
                     self.handleStatus(status: status)
                 }, onError: { error in
                     self.handleError(error)
@@ -304,7 +311,9 @@ class ViewController: UIViewController {
         alert.addTextField { $0.placeholder = "Code" }
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak factor] action in
             guard let code = alert.textFields?[0].text else { return }
+            
             factor?.verify(passCode: code,
+                           rememberDevice: self.rememberSwitch.isOn,
                            onStatusChange: { status in
                             self.handleStatus(status: status)
             },
@@ -323,7 +332,9 @@ class ViewController: UIViewController {
         alert.addTextField { $0.placeholder = "Code" }
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak factor] action in
             guard let code = alert.textFields?[0].text else { return }
+            
             factor?.verify(passCode: code,
+                           rememberDevice: self.rememberSwitch.isOn,
                            onStatusChange: { status in
                             self.handleStatus(status: status)
             },
@@ -342,7 +353,9 @@ class ViewController: UIViewController {
         alert.addTextField { $0.placeholder = "Answer" }
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak factor] action in
             guard let answer = alert.textFields?[0].text else { return }
+            
             factor?.verify(answerToSecurityQuestion: answer,
+                           rememberDevice: self.rememberSwitch.isOn,
                            onStatusChange: { status in
                             self.handleStatus(status: status)
             },
@@ -357,7 +370,8 @@ class ViewController: UIViewController {
     }
 
     func handlePushChallenge(factor: OktaFactorPush) {
-        factor.verify(onStatusChange: { (status) in
+        factor.verify(rememberDevice: self.rememberSwitch.isOn,
+                      onStatusChange: { (status) in
             if status.factorResult == .waiting {
                 self.updateStatus(status: status)
                 DispatchQueue.main.asyncAfter(deadline:.now() + 5.0) {
@@ -386,5 +400,15 @@ class ViewController: UIViewController {
                 self.handleError(error)
             })
         }
+    }
+    
+    private func makeDeviceToken() -> String? {
+        guard let identifierForVendor = UIDevice.current.identifierForVendor else {
+            return nil
+        }
+        
+        let maximumDeviceTokenLength = 32
+        
+        return String(identifierForVendor.uuidString.prefix(maximumDeviceTokenLength))
     }
 }

--- a/Example/Source/ViewController.swift
+++ b/Example/Source/ViewController.swift
@@ -130,7 +130,6 @@ class ViewController: UIViewController {
 
     func updateStatus(status: OktaAuthStatus?, factorResult: OktaAPISuccessResponse.FactorResult? = nil) {
         guard let status = status else {
-//            rememberSwitch.isOn = false
             stateLabel.text = "Unauthenticated"
             return
         }
@@ -148,9 +147,6 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: "Hooray!", message: "We are logged in", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         present(alert, animated: true, completion: nil)
-
-//        self.loginButton.isEnabled = false
-//        self.cancelButton.isEnabled = false
     }
 
     func handleError(_ error: OktaError) {

--- a/Source/Factors/OktaFactor.swift
+++ b/Source/Factors/OktaFactor.swift
@@ -150,6 +150,7 @@ open class OktaFactor {
 
     public func verify(passCode: String?,
                        answerToSecurityQuestion: String?,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
         guard canVerify() else {
@@ -160,6 +161,7 @@ open class OktaFactor {
         self.verifyFactor(with: verifyLink!,
                           answer: answerToSecurityQuestion,
                           passCode: passCode,
+                          rememberDevice: rememberDevice,
                           onStatusChange: onStatusChange,
                           onError: onError)
     }
@@ -175,6 +177,7 @@ open class OktaFactor {
         self.verifyFactor(with: activationLink!,
                           answer: nil,
                           passCode: passCode,
+                          rememberDevice: nil,
                           onStatusChange: onStatusChange,
                           onError: onError)
     }
@@ -206,16 +209,18 @@ open class OktaFactor {
         })
     }
 
-    public func select(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
+    public func select(rememberDevice: Bool? = nil,
+                       onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
-        guard canSelect() else {
+        guard canSelect(), let verifyLink = links?.verify else {
             onError(OktaError.wrongStatus("Can't find 'verify' link in response"))
             return
         }
 
-        self.verifyFactor(with: links!.verify!,
+        self.verifyFactor(with: verifyLink,
                           answer: nil,
                           passCode: nil,
+                          rememberDevice: rememberDevice,
                           onStatusChange: onStatusChange,
                           onError: onError)
     }
@@ -233,13 +238,14 @@ open class OktaFactor {
     func verifyFactor(with link: LinksResponse.Link,
                       answer: String?,
                       passCode: String?,
+                      rememberDevice: Bool? = nil,
                       onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                       onError: @escaping (_ error: OktaError) -> Void) {
             restApi?.verifyFactor(with: link,
                                   stateToken: stateToken,
                                   answer: answer,
                                   passCode: passCode,
-                                  rememberDevice: nil,
+                                  rememberDevice: rememberDevice,
                                   autoPush: nil,
                                   completion:  { result in
                                     self.handleServerResponse(response: result,

--- a/Source/Factors/OktaFactorCall.swift
+++ b/Source/Factors/OktaFactorCall.swift
@@ -33,10 +33,12 @@ open class OktaFactorCall : OktaFactor {
     }
 
     public func verify(passCode: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
+                     rememberDevice: rememberDevice,
                      onStatusChange: onStatusChange,
                      onError: onError)
     }

--- a/Source/Factors/OktaFactorPush.swift
+++ b/Source/Factors/OktaFactorPush.swift
@@ -157,15 +157,18 @@ open class OktaFactorPush : OktaFactor {
         super.activate(passCode: nil, onStatusChange: onStatusChange, onError: onError)
     }
 
-    public func verify(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
+    public func verify(rememberDevice: Bool? = nil,
+                       onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: nil,
                      answerToSecurityQuestion: nil,
+                     rememberDevice: rememberDevice,
                      onStatusChange: onStatusChange,
                      onError: onError)
     }
 
-    public func checkFactorResult(onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
+    public func checkFactorResult(rememberDevice: Bool? = nil,
+                                  onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                                   onError: @escaping (_ error: OktaError) -> Void) {
         guard canActivate() || canVerify() else {
             onError(OktaError.wrongStatus("Can't find 'poll' link in response"))
@@ -182,6 +185,7 @@ open class OktaFactorPush : OktaFactor {
         self.verifyFactor(with: pollLink!,
                           answer: nil,
                           passCode: nil,
+                          rememberDevice: rememberDevice,
                           onStatusChange: onStatusChange,
                           onError: onError)
     }

--- a/Source/Factors/OktaFactorQuestion.swift
+++ b/Source/Factors/OktaFactorQuestion.swift
@@ -56,6 +56,7 @@ open class OktaFactorQuestion : OktaFactor {
     }
 
     public func select(answerToSecurityQuestion: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (OktaAuthStatus) -> Void,
                        onError: @escaping (OktaError) -> Void) {
         guard canSelect() else {
@@ -66,15 +67,18 @@ open class OktaFactorQuestion : OktaFactor {
         self.verifyFactor(with: links!.verify!,
                           answer: answerToSecurityQuestion,
                           passCode: nil,
+                          rememberDevice: rememberDevice,
                           onStatusChange: onStatusChange,
                           onError: onError)
     }
 
     public func verify(answerToSecurityQuestion: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (OktaAuthStatus) -> Void,
                        onError: @escaping (OktaError) -> Void) {
         super.verify(passCode: nil,
                      answerToSecurityQuestion: answerToSecurityQuestion,
+                     rememberDevice: rememberDevice,
                      onStatusChange: onStatusChange,
                      onError: onError)
     }

--- a/Source/Factors/OktaFactorSms.swift
+++ b/Source/Factors/OktaFactorSms.swift
@@ -33,10 +33,12 @@ open class OktaFactorSms : OktaFactor {
     }
 
     public func verify(passCode: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
+                     rememberDevice: rememberDevice,
                      onStatusChange: onStatusChange,
                      onError: onError)
     }

--- a/Source/Factors/OktaFactorToken.swift
+++ b/Source/Factors/OktaFactorToken.swift
@@ -40,18 +40,22 @@ open class OktaFactorToken : OktaFactor {
     }
 
     public func select(passCode: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (OktaAuthStatus) -> Void,
                        onError: @escaping (OktaError) -> Void) {
         self.verify(passCode: passCode,
+                    rememberDevice: rememberDevice,
                     onStatusChange: onStatusChange,
                     onError: onError)
     }
     
     public func verify(passCode: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
+                     rememberDevice: rememberDevice,
                      onStatusChange: onStatusChange,
                      onError: onError)
     }

--- a/Source/Factors/OktaFactorTotp.swift
+++ b/Source/Factors/OktaFactorTotp.swift
@@ -50,20 +50,24 @@ open class OktaFactorTotp : OktaFactor {
     }
 
     public func select(passCode: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (OktaAuthStatus) -> Void,
                        onError: @escaping (OktaError) -> Void) {
         self.verifyFactor(with: links!.verify!,
                           answer: nil,
                           passCode: passCode,
+                          rememberDevice: rememberDevice,
                           onStatusChange: onStatusChange,
                           onError: onError)
     }
     
     public func verify(passCode: String,
+                       rememberDevice: Bool? = nil,
                        onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                        onError: @escaping (_ error: OktaError) -> Void) {
         super.verify(passCode: passCode,
                      answerToSecurityQuestion: nil,
+                     rememberDevice: rememberDevice,
                      onStatusChange: onStatusChange,
                      onError: onError)
     }

--- a/Source/OktaAuthSdk.swift
+++ b/Source/OktaAuthSdk.swift
@@ -17,12 +17,14 @@ public class OktaAuthSdk {
     public class func authenticate(with url: URL,
                                    username: String,
                                    password: String?,
+                                   deviceToken: String? = nil,
                                    onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                                    onError: @escaping (_ error: OktaError) -> Void) {
         
         let unauthenticatedStatus = OktaAuthStatusUnauthenticated(oktaDomain: url)
         unauthenticatedStatus.authenticate(username: username,
                                            password: password ?? "",
+                                           deviceToken: deviceToken,
                                            onStatusChange:onStatusChange,
                                            onError:onError)
     }

--- a/Source/Statuses/OktaAuthStatusFactorChallenge.swift
+++ b/Source/Statuses/OktaAuthStatusFactorChallenge.swift
@@ -59,10 +59,12 @@ open class OktaAuthStatusFactorChallenge : OktaAuthStatus {
 
     open func verifyFactor(passCode: String?,
                            answerToSecurityQuestion: String?,
+                           rememberDevice: Bool? = nil,
                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                            onError: @escaping (_ error: OktaError) -> Void) {
         self.factor.verify(passCode: passCode,
                            answerToSecurityQuestion: answerToSecurityQuestion,
+                           rememberDevice: rememberDevice,
                            onStatusChange: onStatusChange,
                            onError: onError)
     }

--- a/Source/Statuses/OktaAuthStatusFactorRequired.swift
+++ b/Source/Statuses/OktaAuthStatusFactorRequired.swift
@@ -45,10 +45,11 @@ open class OktaAuthStatusFactorRequired : OktaAuthStatus {
     }()
 
     open func selectFactor(_ factor: OktaFactor,
+                           rememberDevice: Bool? = nil,
                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                            onError: @escaping (_ error: OktaError) -> Void) {
         selectedFactor = factor
-        factor.select(onStatusChange: onStatusChange, onError: onError)
+        factor.select(rememberDevice: rememberDevice, onStatusChange: onStatusChange, onError: onError)
     }
 
     override open func cancel(onSuccess: (() -> Void)? = nil,

--- a/Source/Statuses/OktaAuthStatusUnauthenticated.swift
+++ b/Source/Statuses/OktaAuthStatusUnauthenticated.swift
@@ -21,11 +21,13 @@ open class OktaAuthStatusUnauthenticated : OktaAuthStatus {
 
     open func authenticate(username: String,
                            password: String,
+                           deviceToken: String? = nil,
                            onStatusChange: @escaping (_ newStatus: OktaAuthStatus) -> Void,
                            onError: @escaping (_ error: OktaError) -> Void) {
 
         restApi.primaryAuthentication(username: username,
                                       password: password,
+                                      deviceToken: deviceToken,
                                       deviceFingerprint: nil)
         { result in
             self.handleServerResponse(result,

--- a/Tests/Factors/OktaFactorCallTests.swift
+++ b/Tests/Factors/OktaFactorCallTests.swift
@@ -170,6 +170,7 @@ class OktaFactorCallTests: OktaFactorTestCase {
         
         factor.verify(
             passCode: "1234",
+            rememberDevice: true,
             onStatusChange: { status in
                 XCTAssertEqual(delegate.changedStatus?.statusType, status.statusType)
                 ex.fulfill()
@@ -202,6 +203,7 @@ class OktaFactorCallTests: OktaFactorTestCase {
         
         factor.verify(
             passCode: "1234",
+            rememberDevice: true,
             onStatusChange: { status in
                 XCTFail("Operation should fail!")
                 ex.fulfill()

--- a/Tests/Factors/OktaFactorPushTests.swift
+++ b/Tests/Factors/OktaFactorPushTests.swift
@@ -316,6 +316,7 @@ class OktaFactorPushTests: OktaFactorTestCase {
         let ex = expectation(description: "Operation should succeed!")
         
         factor.verify(
+            rememberDevice: true,
             onStatusChange: { status in
                 XCTAssertEqual(delegate.changedStatus?.statusType, status.statusType)
                 ex.fulfill()
@@ -346,6 +347,7 @@ class OktaFactorPushTests: OktaFactorTestCase {
         let ex = expectation(description: "Operation should fail!")
         
         factor.verify(
+            rememberDevice: true,
             onStatusChange: { status in
                 XCTFail("Operation should fail!")
                 ex.fulfill()

--- a/Tests/Factors/OktaFactorQuestionTests.swift
+++ b/Tests/Factors/OktaFactorQuestionTests.swift
@@ -145,6 +145,7 @@ class OktaFactorQuestionTests: OktaFactorTestCase {
         
         factor.verify(
             answerToSecurityQuestion: "test",
+            rememberDevice: false,
             onStatusChange: { status in
                 XCTAssertEqual(delegate.changedStatus?.statusType, status.statusType)
                 ex.fulfill()
@@ -177,6 +178,7 @@ class OktaFactorQuestionTests: OktaFactorTestCase {
         
         factor.verify(
             answerToSecurityQuestion: "test",
+            rememberDevice: true,
             onStatusChange: { status in
                 XCTFail("Operation should fail!")
                 ex.fulfill()

--- a/Tests/Factors/OktaFactorSmsTests.swift
+++ b/Tests/Factors/OktaFactorSmsTests.swift
@@ -168,6 +168,7 @@ class OktaFactorSmsTests: OktaFactorTestCase {
         
         factor.verify(
             passCode: "1234",
+            rememberDevice: false,
             onStatusChange: { status in
                 XCTAssertEqual(delegate.changedStatus?.statusType, status.statusType)
                 ex.fulfill()
@@ -200,6 +201,7 @@ class OktaFactorSmsTests: OktaFactorTestCase {
         
         factor.verify(
             passCode: "1234",
+            rememberDevice: false,
             onStatusChange: { status in
                 XCTFail("Operation should fail!")
                 ex.fulfill()

--- a/Tests/Factors/OktaFactorTotpTests.swift
+++ b/Tests/Factors/OktaFactorTotpTests.swift
@@ -108,6 +108,7 @@ class OktaFactorTotpTests: OktaFactorTestCase {
         
         factor.verify(
             passCode: "1234",
+            rememberDevice: true,
             onStatusChange: { status in
                 XCTAssertEqual(delegate.changedStatus?.statusType, status.statusType)
                 ex.fulfill()
@@ -140,6 +141,7 @@ class OktaFactorTotpTests: OktaFactorTestCase {
         
         factor.verify(
             passCode: "1234",
+            rememberDevice: nil,
             onStatusChange: { status in
                 XCTFail("Operation should fail!")
                 ex.fulfill()

--- a/Tests/Statuses/OktaAuthStatusUnauthenticatedTests.swift
+++ b/Tests/Statuses/OktaAuthStatusUnauthenticatedTests.swift
@@ -26,6 +26,7 @@ class OktaAuthStatusUnauthenticatedTests: XCTestCase {
         status.authenticate(
             username: "test",
             password: "test",
+            deviceToken: "Device-Token-123",
             onStatusChange: { status in
                 XCTAssertEqual(AuthStatus.success, status.statusType)
                 ex.fulfill()


### PR DESCRIPTION
### Problem Analysis (Technical)
The library does not expose `rememberDevice` and `deviceToken` parameters. 
The feature was requested by the reporter in [oidc-ios repo](https://github.com/okta/okta-oidc-ios/issues/277).

### Solution (Technical)
Make `rememberDevice` and `deviceToken` available for developers.

### Tests
Added parameters in tests. 
I didn't add the integration tests which assure that MFA is not asked one more time and device is remembered. Because it involves additional Policy rules. Also, I don't know which org is used because global variables are hidden in Travis settings.

If you see it's something required I can work on that more.