### PR TITLE
fix exclude warning on Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "OktaAuthNative", targets: ["OktaAuthNative"])
     ],
     targets: [
-        .target(name: "OktaAuthNative", dependencies: [], path: "Source", exclude: ["Source/Info.plist"]),
+        .target(name: "OktaAuthNative", dependencies: [], path: "Source", exclude: ["Info.plist"]),
         .testTarget(name: "OktaAuthNative_Tests", dependencies: ["OktaAuthNative"], path: "Tests", exclude: ["AuthenticationClientTests.swift"])
     ]
 )


### PR DESCRIPTION
### Problem Analysis (Technical)
When compiling a project with okta-auth-swift 2.4.2 as a dependency, the following warning would exist.

Invalid Exclude '/Users/kqiu.ciic/Library/Developer/Xcode/DerivedData/SmsLiteMobile-gindekpxgrmcfreyrokfwfmqdwwb/SourcePackages/checkouts/okta-auth-swift/Source/Source/Info.plist': File not found.

see also https://github.com/tid-kijyun/Kanna/pull/249

### Solution (Technical)
correct the path

### Affected Components


### Steps to reproduce:

simply compile

Actual result:
get warning

Expected result:
no warning

### Tests
compile and get no warning
