### PR TITLE
Send the Device Token in a cookie HTTP request header

### DIFF
--- a/OktaAuthSdk.podspec
+++ b/OktaAuthSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'OktaAuthSdk'
-  s.version          = '2.4.4'
+  s.version          = '2.4.5'
   s.summary          = 'SDK for Okta native authentication.'
   s.description      = <<-DESC
 Integrate your native app with Okta.

--- a/Source/RestAPI/OktaAPI.swift
+++ b/Source/RestAPI/OktaAPI.swift
@@ -52,15 +52,30 @@ open class OktaAPI {
         bodyParams["relayState"] = relayState
         bodyParams["options"] = ["multiOptionalFactorEnroll": multiOptionalFactorEnroll,
                                  "warnBeforePasswordExpired": warnBeforePasswordExpired]
-        var context: [String: String] = [:]
-        context["deviceToken"] = deviceToken
-        bodyParams["context"] = context
         bodyParams["token"] = token
         req.bodyParams = bodyParams
+
+        var additionalHeaders = req.additionalHeaders ?? [:]
+        if let deviceToken = deviceToken {
+            var cookies = ["DT=\(deviceToken)"]
+            if let cookieHeader = req.additionalHeaders?["Cookie"] as? String {
+                cookies.append(contentsOf: cookieHeader
+                    .components(separatedBy: ";")
+                    .map({ $0.trimmingCharacters(in: .whitespaces) }))
+            }
+            
+            additionalHeaders["Cookie"] = cookies.joined(separator: "; ")
+        }
+
         
         if let deviceFingerprint = deviceFingerprint {
-            req.additionalHeaders = ["X-Device-Fingerprint": deviceFingerprint]
+            additionalHeaders["X-Device-Fingerprint"] = deviceFingerprint
         }
+        
+        if !additionalHeaders.isEmpty {
+            req.additionalHeaders = additionalHeaders
+        }
+        
         req.run()
         return req
     }

--- a/Tests/RestAPI/OktaAPITests.swift
+++ b/Tests/RestAPI/OktaAPITests.swift
@@ -44,6 +44,27 @@ class OktaAPITests : XCTestCase {
         wait(for: [exp], timeout: 60.0)
     }
     
+    func testPrimaryAuthenticationWithDeviceToken() {
+        let username = "username"
+        let password = "password"
+        let deviceToken = "abcd123"
+        
+        let exp = XCTestExpectation()
+        api.commonCompletion = { req, _ in
+            XCTAssertEqual(req.baseURL, self.url)
+            XCTAssertEqual(req.path, "/api/v1/authn")
+            XCTAssertEqual(req.bodyParams?["username"] as? String, username)
+            XCTAssertEqual(req.bodyParams?["password"] as? String, password)
+            XCTAssertNil(req.bodyParams?["context"])
+            XCTAssertEqual(req.additionalHeaders?["Cookie"], "DT=\(deviceToken)")
+            exp.fulfill()
+        }
+        
+        api.primaryAuthentication(username: username, password: password, deviceToken: deviceToken)
+        
+        wait(for: [exp], timeout: 60.0)
+    }
+
     func testPrimaryAuthenticationWithDeviceFingerprint() {
         let username = "username"
         let password = "password"


### PR DESCRIPTION
Supplying the deviceToken to the server within the HTTP request body is deprecated, and no longer supported. This update is to send the value through the appropriate cookie header value instead.